### PR TITLE
feat(optimization-readiness): add readiness analysis skill [NT-2949]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ out/
 
 # Logs
 *.log
+
+# Local research docs
+.docs/

--- a/skills/optimization/optimization-readiness/SKILL.md
+++ b/skills/optimization/optimization-readiness/SKILL.md
@@ -2,12 +2,244 @@
 name: optimization-readiness
 description: >-
   Assess whether a codebase is ready for Contentful optimization and personalization.
-  Analyzes component structure, rendering patterns, and SDK compatibility.
-  Use when asked to check optimization readiness, audit personalization setup,
-  evaluate prerequisites, or determine if a project can support personalization.
-  Also triggers on "am I ready for personalization" or "can my app support A/B testing".
+  Analyzes framework, Contentful SDK setup, component architecture, and rendering
+  pipeline by reading code — no execution, no API calls. Produces a readiness report
+  with actionable recommendations. Use when asked to check optimization readiness,
+  audit personalization setup, evaluate prerequisites, determine if a project can
+  support personalization or A/B testing. Also triggers on "am I ready for
+  personalization", "can I install Ninetailed", "is my project ready", "evaluate my
+  codebase", "readiness check", "can my app support A/B testing". Not for installing
+  or configuring SDKs — use $optimization-setup for that. Not for diagnosing issues
+  in an existing setup — use $optimization-doctor for that.
 ---
 
 # Optimization Readiness
 
-> This skill is under development.
+Analyze a customer's codebase and produce a readiness report for Contentful
+personalization, optimization, and analytics.
+
+This is a **read-only analysis** — read files, search code, inspect configs.
+Do not run the project, execute scripts, or call external APIs.
+
+## Procedure
+
+Run checks A through E in order. For each check, report what you found and
+assess readiness. Then produce the final report.
+
+### A. Framework Detection
+
+**Goal**: Identify the framework, version, router type, and rendering mode.
+
+1. Read `package.json` — look for `next`, `gatsby`, `remix`, `react-scripts`,
+   `vite` in dependencies or devDependencies
+2. If Next.js:
+   - Check version in package.json (App Router requires 13.4+)
+   - Check for `app/` directory → App Router; `pages/` directory → Pages Router;
+     both may coexist
+   - Search for rendering indicators:
+     - `getServerSideProps` → SSR
+     - `getStaticProps` / `generateStaticParams` → SSG
+     - `revalidate` in getStaticProps return → ISR
+     - `'use client'` directives → Client Components (App Router)
+     - Server Components (default in App Router `app/` dir)
+3. If Gatsby: check for `gatsby-config.js/ts`, `gatsby-browser.js/ts`
+4. If Remix: check for `remix.config.js`, `app/routes/` directory
+5. If none of the above: plain React (CRA, Vite, custom)
+
+**Assess**:
+- Next.js (any version) → Fully supported
+- Gatsby → Supported (client-side only)
+- Remix → Partially supported (community patterns)
+- Plain React → Supported (client-side only)
+- Non-React framework → Not currently supported
+
+### B. Contentful SDK Setup
+
+**Goal**: Determine if Contentful is integrated and how.
+
+1. Check `package.json` for:
+   - `contentful` (Delivery/Preview SDK)
+   - `@contentful/rich-text-react-renderer` (rich text)
+   - `contentful-management` (Management API)
+2. Search source code for `createClient` calls from `contentful` package
+3. If client found, check:
+   - Is `space` configured? (hardcoded or env var)
+   - Is `accessToken` configured?
+   - Is there a preview client? (look for `host: 'preview.contentful.com'`)
+4. Check for environment variables in `.env*` files and code:
+   - `CONTENTFUL_SPACE_ID` or `NEXT_PUBLIC_CONTENTFUL_SPACE_ID`
+   - `CONTENTFUL_TOKEN` or `NEXT_PUBLIC_CONTENTFUL_TOKEN` (delivery)
+   - `CONTENTFUL_PREVIEW_TOKEN` or `NEXT_PUBLIC_CONTENTFUL_PREVIEW_TOKEN`
+5. Check the `include` depth in Contentful queries — personalization needs
+   at least 2 levels of reference resolution
+
+**Assess**:
+- SDK installed + client configured + env vars present → Ready
+- SDK installed but client not found → Needs configuration
+- No Contentful SDK → Must install first
+
+### C. Existing Ninetailed Setup
+
+**Goal**: Detect if personalization is already (partially) installed.
+
+1. Check `package.json` for any `@ninetailed/experience.js*` packages:
+   - `@ninetailed/experience.js` (core)
+   - `@ninetailed/experience.js-react` (React bindings)
+   - `@ninetailed/experience.js-next` (Next.js)
+   - `@ninetailed/experience.js-plugin-*` (plugins)
+   - `@ninetailed/experience.js-utils-contentful` (Contentful utilities)
+2. Search for `NinetailedProvider` in source files
+3. Search for `<Experience` component usage
+4. Check for environment variables:
+   - `NINETAILED_CLIENT_ID` or `NEXT_PUBLIC_NINETAILED_CLIENT_ID`
+   - `NINETAILED_ENVIRONMENT` or `NEXT_PUBLIC_NINETAILED_ENVIRONMENT`
+5. If provider found, check which plugins are configured:
+   - `NinetailedInsightsPlugin` or `NinetailedAnalyticsPlugin` → analytics
+   - `NinetailedPreviewPlugin` → preview editor
+   - `NinetailedSsrPlugin` → server-side rendering
+   - `NinetailedPrivacyPlugin` → consent management
+
+**Assess**:
+- No packages installed → Fresh setup (use $optimization-setup)
+- Packages installed but no provider → Partially configured, needs completion
+- Provider configured with plugins → Already set up (check completeness)
+
+### D. Component Architecture
+
+**This is the most important check.** Personalization wraps components with
+an `<Experience>` component that swaps the baseline for a variant. This only
+works if components are self-contained and rendered via a content type mapper.
+
+1. **Search for the component mapper pattern**:
+   - Object maps: `{ hero: Hero, cta: CTA, ... }` or similar
+   - Switch statements on `sys.contentType.sys.id` or `__typename`
+   - Dynamic imports or lookups based on content type
+   - Common file names: `BlockRenderer`, `ComponentRenderer`, `ContentTypeMapper`,
+     `DynamicComponent`, `SectionRenderer`
+
+2. **Assess component isolation**:
+   - Do components receive all data via props? (good)
+   - Do components fetch their own data internally? (problem — can't swap variants)
+   - Are components tightly coupled to parent state? (problem)
+   - Do components have side effects that depend on specific content? (problem)
+
+3. **Check for existing experience integration**:
+   - Search for `nt_experiences` field references in code
+   - Search for `ExperienceMapper` usage
+   - Search for `<Experience` component usage
+   - If found: which content types are already wrapped?
+
+4. **Identify personalizable content types**:
+   - Look at the component mapper — which content types have corresponding components?
+   - Which of these represent above-the-fold or high-value content?
+     (heroes, banners, CTAs, pricing tables, feature sections)
+   - Are there content types with no component mapping?
+
+**Assess**:
+- Component mapper found + components are isolated → Ready for personalization
+- No mapper but components are isolated → Needs a mapper (moderate effort)
+- Components fetch their own data → Needs refactoring (significant effort)
+- No clear component/content type structure → Significant restructuring needed
+
+For detailed patterns, see [references/component-patterns.md](references/component-patterns.md).
+
+### E. Rendering Pipeline
+
+**Goal**: Assess whether the data-fetching pattern supports personalization.
+
+1. **Identify the data-fetching layer**:
+   - Next.js Pages Router: `getStaticProps`, `getServerSideProps`
+   - Next.js App Router: server components, `fetch()` in RSC
+   - Gatsby: `gatsby-node.js` + GraphQL queries
+   - Remix: `loader` functions
+   - Client-only: `useEffect` + API calls
+
+2. **Check fetching location**:
+   - Page level (good) — content fetched once, passed down to components
+   - Component level (harder) — each component fetches its own data
+   - Mixed — some page-level, some component-level
+
+3. **Check for hard-coded content**:
+   - Components with literal text/images that should come from Contentful
+   - These can't be personalized until migrated to CMS content
+
+4. **Check Contentful query depth**:
+   - The `include` parameter in `getEntries` calls
+   - Needs at least 2 for experiences to resolve (entry → experience → variant)
+   - Check if `.withoutUnresolvableLinks` is used (recommended)
+
+5. **Check for ISR/revalidation**:
+   - `revalidate` in `getStaticProps` return value
+   - ISR is ideal for personalization — static generation with incremental updates
+
+**Assess**:
+- Page-level fetching + sufficient include depth → Ready
+- Component-level fetching → Needs restructuring
+- Hard-coded content → Needs CMS migration
+- Include depth < 2 → Simple fix (increase include value)
+
+For framework-specific notes, see [references/framework-notes.md](references/framework-notes.md).
+
+## Report Format
+
+After completing all checks, produce a report in this format:
+
+```markdown
+## Optimization Readiness Report
+
+### Framework: [Name] [Version] ([Router Type]) [STATUS]
+- [Rendering mode detected]
+- [Compatibility assessment]
+
+### Contentful Setup: [STATUS]
+- [SDK + version status]
+- [Client configuration status]
+- [Environment variables status]
+- [Include depth assessment]
+
+### Existing Ninetailed Setup: [STATUS]
+- [Packages found / not found]
+- [Provider status]
+- [Plugin status]
+
+### Component Architecture: [STATUS]
+- [Mapper pattern found/not]
+- [Component isolation assessment]
+- [Content types with/without mappings]
+- [Personalizable content types identified]
+
+### Rendering Pipeline: [STATUS]
+- [Data fetching pattern]
+- [Fetching location assessment]
+- [Hard-coded content identified]
+
+### Overall: [READY / READY WITH MINOR CHANGES / NEEDS WORK / SIGNIFICANT RESTRUCTURING NEEDED]
+
+### Recommendations
+1. [Specific, actionable next step]
+2. [...]
+3. [...]
+
+Use $optimization-setup for guided installation and configuration.
+```
+
+**Status markers**: Use these consistently:
+- `READY` — No changes needed for this area
+- `MINOR CHANGES` — Small fixes (config tweaks, increasing include depth)
+- `NEEDS WORK` — Moderate effort (add mapper, restructure fetching)
+- `NOT READY` — Significant restructuring required
+
+## Assessment Criteria
+
+For the detailed rubric for each check, see
+[references/readiness-criteria.md](references/readiness-criteria.md).
+
+The **overall assessment** is determined by the worst-performing area:
+- All READY → **READY**
+- Worst is MINOR CHANGES → **READY WITH MINOR CHANGES**
+- Worst is NEEDS WORK → **NEEDS WORK**
+- Any NOT READY → **SIGNIFICANT RESTRUCTURING NEEDED**
+
+Exception: if the only issue is "no Ninetailed packages installed" but
+everything else is ready, the overall assessment is still **READY** — that's
+what $optimization-setup is for.

--- a/skills/optimization/optimization-readiness/SKILL.md
+++ b/skills/optimization/optimization-readiness/SKILL.md
@@ -130,11 +130,14 @@ works if components are self-contained and rendered via a content type mapper.
    - Are components tightly coupled to parent state? (problem)
    - Do components have side effects that depend on specific content? (problem)
 
-3. **Check for existing experience integration**:
-   - Search for `nt_experiences` field references in code
+3. **Check for existing experience integration** (presence is a positive signal;
+   absence tells us nothing — content types may be extended in Contentful
+   without any explicit code references):
+   - Search for `nt_experiences` field references in code or type definitions
    - Search for `ExperienceMapper` usage
    - Search for `<Experience` component usage
-   - If found: which content types are already wrapped?
+   - If found: which content types are already wrapped? This means
+     personalization is already partially integrated.
 
 4. **Identify personalizable content types**:
    - Look at the component mapper — which content types have corresponding components?

--- a/skills/optimization/optimization-readiness/SKILL.md
+++ b/skills/optimization/optimization-readiness/SKILL.md
@@ -5,12 +5,14 @@ description: >-
   Analyzes framework, Contentful SDK setup, component architecture, and rendering
   pipeline by reading code — no execution, no API calls. Produces a readiness report
   with actionable recommendations. Use when asked to check optimization readiness,
-  audit personalization setup, evaluate prerequisites, determine if a project can
-  support personalization or A/B testing. Also triggers on "am I ready for
-  personalization", "can I install Ninetailed", "is my project ready", "evaluate my
-  codebase", "readiness check", "can my app support A/B testing". Not for installing
-  or configuring SDKs — use $optimization-setup for that. Not for diagnosing issues
-  in an existing setup — use $optimization-doctor for that.
+  audit personalization setup, evaluate prerequisites, validate setup, determine if
+  a project can support personalization or A/B testing. Also triggers on "am I ready
+  for personalization", "can I install Ninetailed", "is my project ready", "evaluate
+  my codebase", "readiness check", "can my app support A/B testing", "pre-check",
+  "prerequisites for personalization". Not for installing or configuring SDKs — use
+  $optimization-setup for that. Not for diagnosing issues in an existing setup — use
+  $optimization-doctor for that.
+license: MIT
 ---
 
 # Optimization Readiness
@@ -20,6 +22,11 @@ personalization, optimization, and analytics.
 
 This is a **read-only analysis** — read files, search code, inspect configs.
 Do not run the project, execute scripts, or call external APIs.
+
+For background on how personalization works (the content model, rendering
+flow, and why each check matters), see
+[references/how-personalization-works.md](references/how-personalization-works.md).
+Read it before starting if you're unfamiliar with Ninetailed.
 
 ## Procedure
 
@@ -163,20 +170,33 @@ For detailed patterns, see [references/component-patterns.md](references/compone
    - Components with literal text/images that should come from Contentful
    - These can't be personalized until migrated to CMS content
 
-4. **Check Contentful query depth**:
-   - The `include` parameter in `getEntries` calls
-   - Needs at least 2 for experiences to resolve (entry → experience → variant)
+4. **Check Contentful query depth** (critical — see how-personalization-works.md):
+   - Search for `.include(` or `include:` in `getEntries`/`getEntry` calls
+   - Parse the actual numeric value:
+     - `include: 3` or higher → good (entry → experience → variant all resolved)
+     - `include: 2` → minimum viable (works with `.withoutUnresolvableLinks`)
+     - `include: 1` or `include: 0` → experiences won't resolve; MINOR CHANGES
+     - No include parameter → defaults vary by SDK version; flag for review
+   - No Contentful queries found at all → content not from CMS; NEEDS WORK
    - Check if `.withoutUnresolvableLinks` is used (recommended)
 
 5. **Check for ISR/revalidation**:
    - `revalidate` in `getStaticProps` return value
    - ISR is ideal for personalization — static generation with incremental updates
 
+6. **Note SSR/edge capability** (not a blocker — just capability assessment):
+   - Search for `middleware.ts` or `middleware.js` → Next.js edge middleware
+   - Search for `wrangler.toml` → Cloudflare Workers
+   - Search for `@ninetailed/experience.js-plugin-ssr` in package.json
+   - If any found: note "SSR/edge-side personalization possible (no flash of default content)"
+   - If none: note "Client-side personalization only (baseline shows briefly before variant swap)"
+
 **Assess**:
-- Page-level fetching + sufficient include depth → Ready
+- Page-level fetching + include ≥ 2 → Ready
 - Component-level fetching → Needs restructuring
 - Hard-coded content → Needs CMS migration
 - Include depth < 2 → Simple fix (increase include value)
+- No Contentful queries → Content not from CMS; needs migration
 
 For framework-specific notes, see [references/framework-notes.md](references/framework-notes.md).
 
@@ -228,6 +248,51 @@ Use $optimization-setup for guided installation and configuration.
 - `MINOR CHANGES` — Small fixes (config tweaks, increasing include depth)
 - `NEEDS WORK` — Moderate effort (add mapper, restructure fetching)
 - `NOT READY` — Significant restructuring required
+
+## Example Report
+
+```markdown
+## Optimization Readiness Report
+
+### Framework: Next.js 14.1.0 (App Router) READY
+- App Router detected (`app/` directory with `layout.tsx`)
+- Server Components with `'use client'` boundaries in place
+- ISR via `revalidate: 5` in multiple routes
+- Compatible with both client-side and server-side personalization
+
+### Contentful Setup: READY
+- `contentful` v10.6.21 installed
+- Client configured in `lib/contentful.ts` with space ID from env var
+- Preview client configured (preview.contentful.com)
+- Include depth: 10 (sufficient)
+- `.withoutUnresolvableLinks` used
+
+### Existing Ninetailed Setup: NOT INSTALLED
+- No `@ninetailed/*` packages in package.json
+- No NinetailedProvider in source
+- Fresh setup — use $optimization-setup for guided installation
+
+### Component Architecture: MINOR CHANGES
+- Component mapper found in `components/Renderer/BlockRenderer.tsx`
+  - Maps 8 content types: hero, cta, feature, banner, pricing, faq, testimonial, footer
+  - Components are well-isolated (props → JSX, no internal data fetching)
+- No `nt_experiences` field references (expected — Ninetailed not yet installed)
+- 2 content types (`callout`, `stat-grid`) have components but are not in the mapper
+- Recommendation: Add `callout` and `stat-grid` to ContentTypeMap
+
+### Rendering Pipeline: READY
+- Data fetched at page level in Server Components
+- Entries passed down as props to Client Component wrappers
+- No hard-coded content detected in personalizable components
+- SSR/edge capability: `middleware.ts` present (edge middleware ready)
+
+### Overall: READY WITH MINOR CHANGES
+
+### Recommendations
+1. Add `callout` and `stat-grid` to the ContentTypeMap in BlockRenderer.tsx
+2. Run $optimization-setup for guided Ninetailed SDK installation
+3. Edge middleware detected — consider server-side personalization for no-flash experience
+```
 
 ## Assessment Criteria
 

--- a/skills/optimization/optimization-readiness/package.json
+++ b/skills/optimization/optimization-readiness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/skill-optimization-readiness",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "Assess optimization and personalization readiness for a Contentful project",
   "license": "MIT",
   "files": ["SKILL.md", "references/**"]

--- a/skills/optimization/optimization-readiness/references/component-patterns.md
+++ b/skills/optimization/optimization-readiness/references/component-patterns.md
@@ -1,0 +1,189 @@
+# Component Patterns
+
+Concrete examples of what a "ready" codebase looks like vs common problems.
+
+## Good Pattern: ContentTypeMap + BlockRenderer
+
+The standard Ninetailed pattern. Found in all official playgrounds and demos.
+
+```typescript
+// components/Renderer/BlockRenderer.tsx
+
+const ContentTypeMap = {
+  hero: Hero,
+  cta: CTA,
+  feature: Feature,
+  banner: Banner,
+  pricingTable: PricingTable,
+};
+
+const BlockRenderer = ({ block }) => {
+  const contentTypeId = block.sys.contentType.sys.id;
+  const Component = ContentTypeMap[contentTypeId];
+  if (!Component) return null;
+
+  // Extract experiences from the Contentful entry
+  const experiences = (block.fields.nt_experiences || [])
+    .filter(ExperienceMapper.isExperienceEntry)
+    .map(ExperienceMapper.mapExperience);
+
+  // Wrap with Experience component for personalization
+  return (
+    <Experience
+      {...block}
+      id={block.sys.id}
+      component={ComponentRenderer}
+      experiences={experiences}
+    />
+  );
+};
+```
+
+**Why this works**: Each content type maps to a self-contained component.
+The `<Experience>` wrapper can swap the baseline entry for a variant entry,
+and the same component renders both. The component doesn't know or care
+whether it's showing the baseline or a variant.
+
+## Good Pattern: Page-Level Data Fetching with ISR
+
+```typescript
+// pages/[[...slug]].tsx
+export const getStaticProps = async ({ params }) => {
+  const [page, experiences, audiences] = await Promise.all([
+    getPage({ slug: params.slug }),
+    getAllExperiences(),
+    getAllAudiences(),
+  ]);
+
+  return {
+    props: {
+      page,
+      ninetailed: { preview: { experiences, audiences } },
+    },
+    revalidate: 5,
+  };
+};
+```
+
+**Why this works**: All content fetched at the page level, passed down as
+props. ISR keeps content fresh without rebuilding. Experiences and audiences
+fetched in parallel for the preview plugin.
+
+## Good Pattern: Isolated Component
+
+```typescript
+// components/Hero/Hero.tsx
+const Hero = ({ fields }) => (
+  <section>
+    <h1>{fields.headline}</h1>
+    <p>{fields.subheadline}</p>
+    <Button href={fields.ctaLink}>{fields.ctaText}</Button>
+    {fields.image && <Image src={fields.image.fields.file.url} />}
+  </section>
+);
+```
+
+**Why this works**: Pure props → JSX. No internal state, no data fetching,
+no side effects. The `<Experience>` wrapper can swap the entire entry and
+the component renders the variant's fields identically.
+
+## Problem Pattern: Component-Level Data Fetching
+
+```typescript
+// BAD: Component fetches its own data
+const Hero = ({ entryId }) => {
+  const [entry, setEntry] = useState(null);
+  useEffect(() => {
+    contentfulClient.getEntry(entryId).then(setEntry);
+  }, [entryId]);
+
+  if (!entry) return <Skeleton />;
+  return <h1>{entry.fields.headline}</h1>;
+};
+```
+
+**Why this breaks**: The `<Experience>` wrapper provides variant data via
+props, but this component ignores props and fetches its own data. Swapping
+the entry ID isn't enough because the component still shows loading state.
+
+**Fix**: Move data fetching to the page level. Pass the full entry as props.
+
+## Problem Pattern: Hardcoded Content
+
+```typescript
+// BAD: Content is hardcoded, not from Contentful
+const Hero = () => (
+  <section>
+    <h1>Welcome to Our Platform</h1>
+    <p>The best solution for your needs</p>
+    <Button href="/signup">Get Started</Button>
+  </section>
+);
+```
+
+**Why this breaks**: Nothing to personalize — the content isn't dynamic.
+You can't swap "Welcome to Our Platform" for a targeted variant because
+there's no Contentful entry backing it.
+
+**Fix**: Create a Contentful content type for this component, migrate the
+content to Contentful entries, and render from entry fields.
+
+## Problem Pattern: Tightly Coupled Components
+
+```typescript
+// BAD: Component depends on parent's data structure
+const ProductSection = ({ pageData }) => {
+  const products = pageData.sections[2].products;
+  const hero = pageData.sections[0];
+  return (
+    <div>
+      <h2>{hero.title}</h2>
+      {products.map(p => <ProductCard key={p.id} {...p} />)}
+    </div>
+  );
+};
+```
+
+**Why this breaks**: The component reaches into specific indices of the
+parent's data structure. It can't be wrapped independently because it
+depends on the full page data, not just its own entry.
+
+**Fix**: Each component should receive only its own content as props.
+The page renders a list of components, each receiving its own entry.
+
+## Problem Pattern: No Component Mapper
+
+```typescript
+// BAD: Components rendered manually in pages
+const HomePage = ({ page }) => (
+  <>
+    <Hero data={page.fields.heroSection} />
+    <Features data={page.fields.featuresSection} />
+    <Pricing data={page.fields.pricingSection} />
+    <Footer />
+  </>
+);
+```
+
+**Why this is harder**: Without a mapper, each personalizable component
+needs its own `<Experience>` wrapper added manually in every page that
+uses it. A mapper centralizes this in one place.
+
+**Fix**: Introduce a `BlockRenderer` that maps content type IDs to components.
+The page renders a list of blocks through the renderer instead of hardcoding
+each section.
+
+## Identifying Personalizable Content Types
+
+Not all content types need personalization. Focus on:
+
+1. **Above-the-fold content**: heroes, banners, main headings
+2. **Conversion elements**: CTAs, pricing tables, signup forms
+3. **Feature highlights**: feature lists, value propositions
+4. **Navigation elements**: menus with personalized links (advanced)
+
+Content types that rarely need personalization:
+- Footer (same for everyone)
+- Legal text, terms of service
+- Site-wide navigation (unless doing nav personalization)
+- Metadata-only entries (SEO, redirects)

--- a/skills/optimization/optimization-readiness/references/framework-notes.md
+++ b/skills/optimization/optimization-readiness/references/framework-notes.md
@@ -1,0 +1,184 @@
+# Framework-Specific Notes
+
+Guidance for personalization readiness by framework.
+
+## Next.js App Router (13.4+)
+
+### Provider Placement
+
+`NinetailedProvider` is a client component — it must be in a Client Component
+boundary. Typically placed in `app/layout.tsx` wrapped with `'use client'`:
+
+```typescript
+// app/providers.tsx
+'use client';
+export function Providers({ children }) {
+  return (
+    <NinetailedProvider clientId={process.env.NEXT_PUBLIC_NINETAILED_CLIENT_ID}>
+      {children}
+    </NinetailedProvider>
+  );
+}
+
+// app/layout.tsx
+import { Providers } from './providers';
+export default function RootLayout({ children }) {
+  return <html><body><Providers>{children}</Providers></body></html>;
+}
+```
+
+### Server Components
+
+Server Components cannot use hooks or context. Personalization must happen
+in Client Components or via edge middleware.
+
+Pattern: fetch content in a Server Component, pass to a Client Component
+that handles personalization:
+
+```typescript
+// app/page.tsx (Server Component)
+export default async function Page() {
+  const entries = await fetchPageContent();
+  return <PersonalizedPage entries={entries} />;
+}
+
+// components/PersonalizedPage.tsx
+'use client';
+export function PersonalizedPage({ entries }) {
+  // Use <Experience> components here
+}
+```
+
+### Key Readiness Signals
+
+- `app/` directory exists → App Router
+- `'use client'` directives present → aware of client/server boundary
+- Data fetching in Server Components → good pattern for personalization
+- Look for a `providers.tsx` or similar client wrapper pattern
+
+## Next.js Pages Router
+
+### Provider Placement
+
+Provider goes in `pages/_app.tsx`:
+
+```typescript
+export default function App({ Component, pageProps }) {
+  return (
+    <NinetailedProvider
+      clientId={process.env.NEXT_PUBLIC_NINETAILED_CLIENT_ID}
+      plugins={[new NinetailedInsightsPlugin()]}
+    >
+      <Component {...pageProps} />
+    </NinetailedProvider>
+  );
+}
+```
+
+### Data Fetching Patterns
+
+- `getStaticProps` + `revalidate` (ISR) → ideal for personalization
+- `getServerSideProps` → works, allows server-side personalization
+- Client-side only (`useEffect`) → works but flash-of-default
+
+### Key Readiness Signals
+
+- `pages/_app.tsx` exists → Pages Router
+- `getStaticProps` with `revalidate` → ISR ready
+- `getServerSideProps` → SSR ready (can add middleware later)
+- `pages/[[...slug]].tsx` or similar catch-all → dynamic routing ready
+
+## Gatsby
+
+### Provider Placement
+
+Provider goes in `gatsby-browser.js` (and `gatsby-ssr.js` for SSR):
+
+```javascript
+// gatsby-browser.js
+export const wrapRootElement = ({ element }) => (
+  <NinetailedProvider clientId={process.env.GATSBY_NINETAILED_CLIENT_ID}>
+    {element}
+  </NinetailedProvider>
+);
+```
+
+### Data Fetching
+
+Gatsby uses GraphQL queries at build time. Content is available via
+`useStaticQuery` or page queries. Personalization is client-side only —
+the static HTML shows the baseline, and the SDK swaps variants after hydration.
+
+### Environment Variables
+
+Gatsby requires `GATSBY_` prefix for client-side env vars:
+```
+GATSBY_NINETAILED_CLIENT_ID
+GATSBY_NINETAILED_ENVIRONMENT
+GATSBY_CONTENTFUL_SPACE_ID
+GATSBY_CONTENTFUL_TOKEN
+```
+
+### Key Readiness Signals
+
+- `gatsby-config.js/ts` exists → Gatsby project
+- `gatsby-source-contentful` plugin → Contentful integrated
+- GraphQL queries for content types → data layer ready
+- `gatsby-browser.js` exists → can add provider
+
+## Remix
+
+### Provider Placement
+
+Provider goes in `app/root.tsx`:
+
+```typescript
+export default function App() {
+  return (
+    <NinetailedProvider clientId={...}>
+      <Outlet />
+    </NinetailedProvider>
+  );
+}
+```
+
+### Data Fetching
+
+Remix uses `loader` functions for server-side data fetching. Content
+is available via `useLoaderData()`. This pattern is compatible with
+personalization — loaders can fetch Contentful entries and pass them
+to components.
+
+### Key Readiness Signals
+
+- `remix.config.js` or `app/root.tsx` → Remix project
+- `loader` functions in route files → data fetching pattern compatible
+- `useLoaderData()` usage → data flows from server to components
+
+## Plain React (CRA / Vite)
+
+### Provider Placement
+
+Provider goes at the app root:
+
+```typescript
+// src/App.tsx or src/main.tsx
+ReactDOM.createRoot(root).render(
+  <NinetailedProvider clientId={...}>
+    <App />
+  </NinetailedProvider>
+);
+```
+
+### Data Fetching
+
+Typically `useEffect` + API calls. Personalization is client-side only.
+Consider:
+- Is there a centralized data-fetching layer?
+- Or does each component fetch its own data?
+
+### Key Readiness Signals
+
+- `react-scripts` or `vite` in deps → CRA or Vite
+- Centralized API client → data fetching can be adapted
+- No SSR capabilities → client-side personalization only

--- a/skills/optimization/optimization-readiness/references/how-personalization-works.md
+++ b/skills/optimization/optimization-readiness/references/how-personalization-works.md
@@ -1,0 +1,196 @@
+# How Contentful Personalization Works
+
+Use this reference to explain your readiness findings to the user. When
+reporting what you found, explain **why** it matters — not just what's
+present or missing.
+
+## The Core Idea
+
+Contentful Personalization (powered by Ninetailed) lets content authors
+create **experiences** — rules that swap content for specific audiences.
+For example: visitors from Germany see a German hero banner, while everyone
+else sees the default.
+
+On the code side, this works by wrapping React components with an
+`<Experience>` component that:
+
+1. Checks which audience the current visitor belongs to
+2. Selects the matching variant (or falls back to baseline)
+3. Renders the same component with the variant's content instead
+
+This is why **component isolation** is the most important readiness factor —
+the component must render identically whether it receives baseline or
+variant content.
+
+## Content Model
+
+Three Contentful content types power personalization:
+
+### nt_experience
+
+An experience defines the personalization rule:
+- Which **audience** to target (reference to `nt_audience`)
+- Which **variants** to show (references to your own content entries)
+- **Distribution** weights (e.g., 50/50 for A/B tests)
+- **Type**: `nt_personalization` (deterministic) or `nt_experiment` (random split)
+
+### nt_audience
+
+An audience defines targeting rules (e.g., "visitors from Germany",
+"returning users", "users with trait plan=enterprise"). Rules are
+evaluated server-side by the Experience API.
+
+### The `nt_experiences` field
+
+Regular content types (hero, banner, CTA, etc.) get an `nt_experiences`
+field added — an array of references to `nt_experience` entries. This
+links a piece of content to the experiences that can personalize it.
+
+**This is why the readiness check looks for `nt_experiences` in code** —
+if content types already have this field, they're already extended for
+personalization.
+
+## The Rendering Flow
+
+```
+1. Page fetches entries from Contentful (including nested nt_experiences)
+          |
+2. For each entry, extract nt_experiences and map them:
+   ExperienceMapper.isExperienceEntry() → filter valid ones
+   ExperienceMapper.mapExperience()     → convert to SDK format
+          |
+3. Wrap the component with <Experience>:
+   <Experience
+     id={entry.sys.id}
+     component={MyComponent}
+     experiences={mappedExperiences}
+     {...entry.fields}
+   />
+          |
+4. The SDK resolves which variant to show:
+   - Checks visitor profile against experience audiences
+   - Selects variant based on distribution weights
+   - Renders MyComponent with variant entry fields (or baseline if no match)
+```
+
+## Why Component Isolation Matters
+
+The `<Experience>` wrapper works by passing different **entry data** to
+the same component. The baseline hero entry has `{ headline: "Welcome" }`,
+and the variant has `{ headline: "Willkommen" }`. The wrapper swaps which
+entry the component receives.
+
+This breaks if the component:
+- **Fetches its own data** — it ignores the variant data passed via props
+- **Has hardcoded content** — there's no entry to swap
+- **Depends on parent state** — can't be wrapped independently
+
+Components that work: receive all content via props, render it, return JSX.
+Pure functions of their input.
+
+## Why the Component Mapper Matters
+
+The `ContentTypeMap` pattern (mapping Contentful content type IDs to React
+components) is important because:
+
+1. It centralizes the content type → component mapping in one place
+2. The `BlockRenderer` can wrap **every** component with `<Experience>`
+   automatically — you don't add wrappers manually per-page
+3. It supports variant rendering: the variant entry has the same content
+   type, so it resolves to the same component
+
+Without a mapper, you'd need to add `<Experience>` wrappers individually
+in every page template for every personalizable component.
+
+## Why Include Depth Matters
+
+When you fetch a page from Contentful, the `include` parameter controls
+how many levels of referenced entries are resolved:
+
+```
+include: 1  →  Page → Section entries (resolved)
+                       ↳ nt_experiences (NOT resolved — just links)
+
+include: 2  →  Page → Section entries (resolved)
+                       ↳ nt_experiences → Experience entries (resolved)
+                                          ↳ Variant entries (NOT resolved)
+
+include: 3  →  Page → Section entries (resolved)
+                       ↳ nt_experiences → Experience entries (resolved)
+                                          ↳ Variant entries (resolved) ✓
+```
+
+With `include < 2`, the `nt_experiences` field contains unresolved links
+instead of full entries. `ExperienceMapper.isExperienceEntry()` filters
+these out, so personalization silently does nothing — the component always
+shows the baseline.
+
+**Recommendation**: `include: 3` or higher for reliable experience resolution.
+At minimum `include: 2` with `.withoutUnresolvableLinks`.
+
+## Client-Side vs Server-Side Personalization
+
+### Client-side (default)
+
+1. Server sends static HTML with baseline content
+2. Browser loads, SDK initializes, contacts Experience API
+3. SDK resolves experiences and swaps components to show variants
+4. **Flash of default content** — user briefly sees baseline before swap
+
+### Server-side / Edge (SSR/ESR)
+
+1. Server/edge contacts Experience API before rendering HTML
+2. HTML is rendered with the personalized variant already in place
+3. Browser receives pre-personalized HTML — **no flash**
+4. Client SDK hydrates for ongoing interactions
+
+Server-side requires:
+- Edge middleware (`middleware.ts`) or a Cloudflare Worker
+- The `@ninetailed/experience.js-plugin-ssr` package
+- Cookie management (`ntaid` cookie for profile identification)
+- Preflight mode (`?type=preflight`) to prevent double-counting events
+
+**This is why the readiness check notes SSR/edge capability** — it's not
+required, but it's the path to the best user experience.
+
+## The Provider
+
+`NinetailedProvider` is a React context provider that:
+- Initializes the Ninetailed SDK with the API key
+- Manages the visitor's profile state
+- Communicates with the Experience API to resolve variants
+- Provides hooks (`useProfile`, `useNinetailed`) to child components
+- Loads plugins (analytics, preview, SSR, privacy)
+
+It must wrap the entire component tree — typically in `_app.tsx` (Pages
+Router) or `app/layout.tsx` (App Router via a Client Component wrapper).
+
+## Package Quick Reference
+
+| Package | What it does |
+|---------|-------------|
+| `@ninetailed/experience.js` | Core SDK — profile management, event tracking, variant resolution |
+| `@ninetailed/experience.js-react` | React integration — Provider, `<Experience>`, hooks |
+| `@ninetailed/experience.js-next` | Next.js auto-page-tracking, ESR support, re-exports React SDK |
+| `@ninetailed/experience.js-shared` | API client, event builders, type definitions |
+| `@ninetailed/experience.js-utils-contentful` | `ExperienceMapper`, `AudienceMapper` for Contentful entries |
+| `@ninetailed/experience.js-plugin-insights` | Tracks component views/clicks/hovers (required for experiment results) |
+| `@ninetailed/experience.js-plugin-preview` | Preview editor UI for testing audiences/experiences in-browser |
+| `@ninetailed/experience.js-plugin-ssr` | Server-side rendering support (cookie-based profile persistence) |
+| `@ninetailed/experience.js-plugin-privacy` | GDPR consent management — filters events based on consent state |
+| `@ninetailed/experience.js-plugin-google-tagmanager` | Pushes personalization events to GTM data layer |
+| `@ninetailed/experience.js-plugin-segment` | Forwards events to Segment CDP |
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `NEXT_PUBLIC_NINETAILED_CLIENT_ID` | API key for the Ninetailed Experience API |
+| `NEXT_PUBLIC_NINETAILED_ENVIRONMENT` | Environment slug (default: `main`) |
+| `NEXT_PUBLIC_CONTENTFUL_SPACE_ID` | Contentful Space ID |
+| `NEXT_PUBLIC_CONTENTFUL_TOKEN` | Contentful Delivery API token |
+| `NEXT_PUBLIC_CONTENTFUL_PREVIEW_TOKEN` | Contentful Preview API token (optional) |
+| `NEXT_PUBLIC_CONTENTFUL_ENVIRONMENT` | Contentful environment (default: `master`) |
+
+Variable prefix depends on framework: `NEXT_PUBLIC_` (Next.js), `GATSBY_`
+(Gatsby), or no prefix (server-only / Remix / plain React).

--- a/skills/optimization/optimization-readiness/references/how-personalization-works.md
+++ b/skills/optimization/optimization-readiness/references/how-personalization-works.md
@@ -43,12 +43,27 @@ evaluated server-side by the Experience API.
 ### The `nt_experiences` field
 
 Regular content types (hero, banner, CTA, etc.) get an `nt_experiences`
-field added — an array of references to `nt_experience` entries. This
-links a piece of content to the experiences that can personalize it.
+field added in Contentful — an array of references to `nt_experience`
+entries. This links a piece of content to the experiences that can
+personalize it. The field is added via the Ninetailed app in the
+Contentful UI, not in code.
 
-**This is why the readiness check looks for `nt_experiences` in code** —
-if content types already have this field, they're already extended for
-personalization.
+When the SDK's `BlockRenderer` accesses `block.fields.nt_experiences`,
+it handles absence gracefully (`|| []`). The field silently appears in
+API responses once the content type is extended — no code changes needed
+for it to show up.
+
+**What finding `nt_experiences` references in code tells you**: the customer
+has already done integration work — they built a BlockRenderer or typed
+their entries to include this field. This means they're **past the setup
+phase** and personalization is wired into their rendering pipeline.
+
+**What NOT finding it tells you**: very little. The content types may or
+may not be extended in Contentful — we can't tell from code alone because
+this skill doesn't make API calls. Many customers use dynamic typing
+and never explicitly reference `nt_experiences` in their TypeScript types.
+The absence is not a problem — it just means we can't assess CMS-side
+readiness from the codebase.
 
 ## The Rendering Flow
 

--- a/skills/optimization/optimization-readiness/references/how-personalization-works.md
+++ b/skills/optimization/optimization-readiness/references/how-personalization-works.md
@@ -24,7 +24,7 @@ variant content.
 
 ## Content Model
 
-Two Contentful content types power personalization:
+Three Contentful content types are installed by the Ninetailed app:
 
 ### nt_experience
 
@@ -39,6 +39,37 @@ An experience defines the personalization rule:
 An audience defines targeting rules (e.g., "visitors from Germany",
 "returning users", "users with trait plan=enterprise"). Rules are
 evaluated server-side by the Experience API.
+
+### nt_mergetag
+
+A merge tag is a content entry that maps a display name to a profile data
+path. Content editors create these in Contentful (e.g., "City of the visitor"
+→ `location.city`). Fields:
+
+| Field | Purpose |
+|-------|---------|
+| `nt_name` | Display name (e.g., "First Name", "City of the visitor") |
+| `nt_mergetag_id` | Dot-notation path into the visitor profile (e.g., `traits.firstName`, `location.city`, `session.count`) |
+| `nt_fallback` | Optional fallback text when the profile value is unavailable |
+
+Merge tags provide **inline personalization** — inserting visitor-specific
+values into content, as opposed to the `<Experience>` component which swaps
+entire component variants.
+
+Two usage paths:
+1. **In rich text** (CMS-authored): editors embed `nt_mergetag` entries
+   inline in Contentful rich text fields. The rich text renderer detects
+   embedded entries with content type `nt_mergetag` and renders a `<MergeTag>`
+   component.
+2. **Direct in code** (developer-authored): use `<MergeTag id="traits.firstName"
+   fallback="friend" />` anywhere in JSX. This bypasses Contentful entries
+   entirely — just reads from the visitor profile.
+
+The `<MergeTag>` React component resolves the `id` path against the current
+visitor profile (via `useProfile()` hook) and renders the value or fallback.
+The path supports both dot notation (`traits.firstName`) and underscore
+notation (`traits_firstName`) — underscores are treated as potential dots
+for backward compatibility.
 
 ### The `nt_experiences` field (on your own content types)
 

--- a/skills/optimization/optimization-readiness/references/how-personalization-works.md
+++ b/skills/optimization/optimization-readiness/references/how-personalization-works.md
@@ -24,7 +24,7 @@ variant content.
 
 ## Content Model
 
-Three Contentful content types power personalization:
+Two Contentful content types power personalization:
 
 ### nt_experience
 
@@ -40,7 +40,7 @@ An audience defines targeting rules (e.g., "visitors from Germany",
 "returning users", "users with trait plan=enterprise"). Rules are
 evaluated server-side by the Experience API.
 
-### The `nt_experiences` field
+### The `nt_experiences` field (on your own content types)
 
 Regular content types (hero, banner, CTA, etc.) get an `nt_experiences`
 field added in Contentful — an array of references to `nt_experience`

--- a/skills/optimization/optimization-readiness/references/readiness-criteria.md
+++ b/skills/optimization/optimization-readiness/references/readiness-criteria.md
@@ -1,0 +1,129 @@
+# Readiness Criteria
+
+Detailed rubric for each readiness check.
+
+## Framework Compatibility
+
+| Framework | Version | Support Level | Notes |
+|-----------|---------|--------------|-------|
+| Next.js (Pages Router) | Any | Full | SSR, SSG, ISR all supported |
+| Next.js (App Router) | 13.4+ | Full | Server Components require client boundary for provider |
+| Gatsby | 4+ | Full (client-side) | No SSR personalization; plugin-based provider |
+| Remix | 1+ | Partial | Community patterns; loader-based data fetching compatible |
+| React (CRA) | 16.8+ | Full (client-side) | Hooks required; no SSR |
+| React (Vite) | 16.8+ | Full (client-side) | Same as CRA |
+| Vue, Svelte, Angular | Any | Not supported | No SDK available |
+| Non-JS frameworks | Any | Not supported | API-only integration possible but no skill coverage |
+
+### Next.js Version Details
+
+- **< 13.0**: Pages Router only. Fully supported.
+- **13.0-13.3**: App Router experimental. Pages Router recommended.
+- **13.4+**: App Router stable. Both routers supported.
+- **14+**: App Router preferred. Server Actions available but not required.
+
+### Rendering Mode Assessment
+
+| Mode | Personalization Support | Notes |
+|------|------------------------|-------|
+| SSR (`getServerSideProps`) | Full + server-side | Can personalize before HTML reaches browser |
+| SSG (`getStaticProps`) | Client-side only | Static HTML, personalization applied after hydration |
+| ISR (`revalidate`) | Client-side + cacheable | Best balance of performance and personalization |
+| Client-only (`useEffect`) | Client-side only | Simplest setup but flash-of-default-content |
+| RSC (Server Components) | Emerging | Provider must be in a Client Component boundary |
+| Edge Middleware | Full + edge-side | Fastest server-side personalization |
+
+## Contentful Setup Rubric
+
+| Criterion | READY | MINOR CHANGES | NEEDS WORK |
+|-----------|-------|---------------|------------|
+| SDK installed | `contentful` in deps | — | Not installed |
+| Client configured | `createClient()` found | Multiple clients not unified | No client setup |
+| Env vars | Space ID + token in .env | Hardcoded values | Neither .env nor hardcoded |
+| Include depth | ≥ 2 in queries | < 2 (easy fix) | No Contentful queries found |
+| Preview client | Configured | — | Not configured (optional) |
+
+## Component Architecture Rubric
+
+This is the most important assessment — it determines how much work is needed.
+
+### Component Isolation
+
+| Level | Description | Assessment |
+|-------|-------------|------------|
+| **Fully isolated** | Props in, JSX out. No internal data fetching. No side effects dependent on specific content. | READY |
+| **Mostly isolated** | Small amount of internal state (e.g., open/close toggle) but content comes from props. | READY |
+| **Partially coupled** | Some data fetching inside component but main content via props. | MINOR CHANGES — extract data fetching |
+| **Tightly coupled** | Component fetches its own content from Contentful internally. | NEEDS WORK — must restructure |
+| **Hardcoded** | Content is literal strings/images in the component. | NOT READY — must migrate to CMS |
+
+### Component Mapper Pattern
+
+| Pattern | Assessment |
+|---------|-----------|
+| Object map (`{ hero: Hero, cta: CTA }`) | READY — standard pattern |
+| Switch statement on content type ID | READY — works but object map is cleaner |
+| Dynamic imports based on content type | READY — works with personalization |
+| No mapper — components rendered manually in page | NEEDS WORK — add a mapper layer |
+| No clear content type → component relationship | NOT READY — need to establish mapping |
+
+### Content Type Coverage
+
+Count how many content types have:
+- A corresponding React component in the mapper
+- All props coming from Contentful entry fields
+
+Report any gaps:
+- Content types with no component → can't personalize these
+- Components not in the mapper → won't receive experience variants
+
+## Rendering Pipeline Rubric
+
+| Criterion | READY | MINOR CHANGES | NEEDS WORK | NOT READY |
+|-----------|-------|---------------|------------|-----------|
+| Fetching location | Page level | Mix of page + some component | All component-level | No clear pattern |
+| Content source | All from Contentful | Mostly CMS, some hardcoded | Mix | Mostly hardcoded |
+| Include depth | ≥ 2 | 1 (increase it) | 0 or not set | No Contentful queries |
+| Data flow | Props down from page | Some context, mostly props | Heavy context/global state | Chaotic |
+
+## Environment Variables Checklist
+
+### Required for Ninetailed (will be needed by $optimization-setup)
+
+```
+NEXT_PUBLIC_NINETAILED_CLIENT_ID    # Ninetailed API key
+NEXT_PUBLIC_NINETAILED_ENVIRONMENT  # Environment slug (default: 'main')
+```
+
+### Required for Contentful (should already exist)
+
+```
+NEXT_PUBLIC_CONTENTFUL_SPACE_ID     # Contentful Space ID
+NEXT_PUBLIC_CONTENTFUL_TOKEN        # Delivery API token
+```
+
+### Recommended
+
+```
+NEXT_PUBLIC_CONTENTFUL_PREVIEW_TOKEN  # Preview API token
+NEXT_PUBLIC_CONTENTFUL_ENVIRONMENT    # Contentful environment (default: 'master')
+CONTENTFUL_MANAGEMENT_TOKEN           # For content type setup
+```
+
+Note: Variable names may use `CONTENTFUL_*` instead of `NEXT_PUBLIC_CONTENTFUL_*`
+depending on whether they're needed client-side. Both patterns are common.
+
+## Overall Assessment Logic
+
+The overall verdict is the **worst** individual assessment, with one exception:
+
+- If the only issue is "no Ninetailed packages installed" (check C) but all
+  other checks pass, the overall is still **READY** — installing packages is
+  what $optimization-setup handles.
+
+| Worst Individual | Overall |
+|-----------------|---------|
+| All READY | **READY** |
+| MINOR CHANGES | **READY WITH MINOR CHANGES** |
+| NEEDS WORK | **NEEDS WORK** |
+| NOT READY | **SIGNIFICANT RESTRUCTURING NEEDED** |

--- a/skills/optimization/optimization-readiness/references/readiness-criteria.md
+++ b/skills/optimization/optimization-readiness/references/readiness-criteria.md
@@ -40,7 +40,7 @@ Detailed rubric for each readiness check.
 | SDK installed | `contentful` in deps | — | Not installed |
 | Client configured | `createClient()` found | Multiple clients not unified | No client setup |
 | Env vars | Space ID + token in .env | Hardcoded values | Neither .env nor hardcoded |
-| Include depth | ≥ 2 in queries | < 2 (easy fix) | No Contentful queries found |
+| Include depth | ≥ 3 in queries | 2 (works with `.withoutUnresolvableLinks`) | < 2 (easy fix — increase value) |
 | Preview client | Configured | — | Not configured (optional) |
 
 ## Component Architecture Rubric
@@ -83,7 +83,7 @@ Report any gaps:
 |-----------|-------|---------------|------------|-----------|
 | Fetching location | Page level | Mix of page + some component | All component-level | No clear pattern |
 | Content source | All from Contentful | Mostly CMS, some hardcoded | Mix | Mostly hardcoded |
-| Include depth | ≥ 2 | 1 (increase it) | 0 or not set | No Contentful queries |
+| Include depth | ≥ 3 | 2 (minimum viable) | 0 or 1 (increase it) | No Contentful queries found |
 | Data flow | Props down from page | Some context, mostly props | Heavy context/global state | Chaotic |
 
 ## Environment Variables Checklist


### PR DESCRIPTION
## Summary

- Build the `optimization-readiness` skill — the first customer-facing skill in this repo
- Analyzes a codebase for Contentful personalization/optimization readiness by reading files (no execution, no API calls)
- Produces a structured readiness report with actionable recommendations

### Readiness checks (5 areas)

1. **Framework Detection** — Next.js (App/Pages Router), Gatsby, Remix, plain React; version and rendering mode
2. **Contentful SDK Setup** — SDK installed, client configured, env vars present, include depth
3. **Existing Ninetailed Setup** — packages, provider, plugins
4. **Component Architecture** (critical) — component mapper pattern, isolation, content type coverage
5. **Rendering Pipeline** — data fetching pattern, page-level vs component-level, hard-coded content

### Reference documents

- `readiness-criteria.md` — detailed rubric and assessment logic
- `component-patterns.md` — good vs problem patterns with code examples
- `framework-notes.md` — Next.js App/Pages Router, Gatsby, Remix, React specifics

### Grounded in real patterns

All checks and patterns derived from actual Ninetailed implementations:
- experience.js SDK playgrounds (Pages Router, App Router)
- contentful-next-esr-demo (edge-side rendering)
- Backend SSR integration skills
- Contentful personalization documentation

## Test plan

- [x] `npx skills add . --list --full-depth` discovers all 5 skills
- [x] SKILL.md under 500 lines (245)
- [ ] Run readiness check against a playground codebase
- [ ] Review report format and recommendations quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)