### PR TITLE
feat(contentful): add contentful specific guide and nextjs skills [NT-2983]

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ npx skills add contentful/skills
 
 ## Available Skills
 
+### Contentful
+
+| Skill | Triggers | Status |
+|-------|----------|--------|
+| **contentful-guide** | "Contentful 101", "which Contentful API should I use", "which skill should I use" | Coming soon |
+| **contentful-nextjs** | "add Contentful to Next.js", "Next.js Contentful setup", "Draft Mode Contentful" | Coming soon |
+
 ### Optimization
 
 | Skill | Triggers | Status |

--- a/skills/contentful/contentful-guide/SKILL.md
+++ b/skills/contentful/contentful-guide/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: contentful-guide
+description: >-
+  Explain core Contentful concepts and route users to the right implementation skill
+  or documentation. Use when users ask "what is" questions, need Contentful
+  terminology clarified, need help choosing between APIs (CDA/CMA/CPA/GraphQL),
+  or ask where to find the correct docs for a task. Also triggers on "Contentful
+  101", "which Contentful API should I use", "how do I get started", and
+  "which skill should I use". Not for framework-specific implementation steps;
+  route those to $contentful-nextjs or other specialized skills.
+---
+
+# Contentful Guide
+
+Use this skill as the routing and vocabulary layer for Contentful tasks.
+
+Contentful is a headless, API-first CMS (composable content platform) where teams model content once and deliver it to many channels.
+
+## What this skill does
+
+1. Clarifies core terms (space, environment, environment alias, content model, content type, entry, asset, locale).
+2. Maps user intent to the right API (CDA, CPA, CMA, GraphQL, Images API).
+3. Routes implementation requests to the right skill and docs.
+4. Prevents incorrect setup by identifying when a request is not in this skill's scope.
+
+## Routing rules
+
+- If the user asks to add Contentful to a Next.js project, use $contentful-nextjs.
+- If the user asks about optimization/personalization/analytics setup or debugging, route to optimization skills.
+- If the user asks for conceptual guidance, architecture tradeoffs, or where to read docs, stay in this skill.
+- If the user asks about environment aliases and deployment workflows, stay in this skill unless they also ask for framework implementation.
+
+## API chooser
+
+- Use **CDA** for published delivery content in websites/apps.
+- Use **CPA** for unpublished preview content.
+- Use **CMA** for write operations (create/update/manage content and models).
+- Use **GraphQL Content API** when query shape control is preferred over REST payloads.
+- Use **Images API** for image transformations.
+
+## Operating pattern
+
+When answering with this skill:
+
+1. Define terms using shared vocabulary from `references/lexicon.md`.
+2. Pick the right docs path from `references/docs-map.md`.
+3. If implementation is requested, hand off using `references/skill-routing.md`.
+4. Keep answers concise and cite canonical docs paths.
+
+## Guardrails
+
+- Do not invent product capabilities, API behavior, or limits.
+- Do not provide framework code unless routing to the specialized implementation skill.
+- Prefer official docs over memory when details may be version-sensitive.
+
+## References
+
+- [Lexicon](references/lexicon.md)
+- [Docs map](references/docs-map.md)
+- [Skill routing](references/skill-routing.md)

--- a/skills/contentful/contentful-guide/package.json
+++ b/skills/contentful/contentful-guide/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@contentful/skill-contentful-guide",
+  "version": "0.0.0",
+  "description": "Contentful concepts and routing guide for choosing skills and docs",
+  "license": "MIT",
+  "files": ["SKILL.md", "references/**"]
+}

--- a/skills/contentful/contentful-guide/references/docs-map.md
+++ b/skills/contentful/contentful-guide/references/docs-map.md
@@ -1,0 +1,28 @@
+# Contentful Docs Map
+
+Use this map to route users quickly to canonical documentation.
+
+## Getting started and concepts
+
+- Beginner context: `https://www.contentful.com/help/getting-started/contentful-101/`
+- API basics: `/developers/docs/concepts/apis/`
+- Domain model: `/developers/docs/concepts/domain-model/`
+- Data model: `/developers/docs/concepts/data-model/`
+- Environment aliases: `/developers/docs/concepts/environment-aliases/`
+- Authentication: `/developers/docs/references/authentication/`
+
+## Platform guidance
+
+- Platforms index (all languages/framework ecosystems):
+  - `https://www.contentful.com/developers/docs/platforms/`
+- JavaScript platform overview and tutorials:
+  - `/developers/docs/javascript/`
+
+## Next.js-specific docs
+
+- Vercel/Next.js guide index:
+  - `/developers/docs/tools/vercel/vercel-nextjs/`
+- Draft mode route handler:
+  - `/developers/docs/tools/vercel/vercel-nextjs/setting-up-draft-mode-route-handler/`
+- Fetching preview content in Draft Mode:
+  - `/developers/docs/tools/vercel/vercel-nextjs/using-draft-mode-to-fetch-unpublished-content-from-contentfuls-apis/`

--- a/skills/contentful/contentful-guide/references/lexicon.md
+++ b/skills/contentful/contentful-guide/references/lexicon.md
@@ -1,0 +1,29 @@
+# Contentful Lexicon
+
+Use these definitions as the default language for user-facing explanations.
+
+Contentful is a headless, API-first CMS (composable content platform) that separates content from presentation and delivers content through APIs.
+
+- **Organization**: Top-level account boundary for users, billing, and one or more spaces.
+- **Space**: Project container for content, settings, and API keys.
+- **Environment**: Isolated version of a space (for example `master`, staging, sandbox).
+- **Environment alias**: Static identifier that points to a target environment and can be switched without changing client-facing IDs.
+- **Master alias**: Default alias ID `master`; it cannot be deleted or renamed.
+- **Content model**: Schema design made of content types and fields.
+- **Content type**: Reusable schema definition (for example `blogPost`) for entries.
+- **Entry**: Structured content item based on a content type.
+- **Asset**: Media object (image/video/file) stored in Contentful.
+- **Locale**: Language-region variant (for example `en-US`) for localized fields.
+
+## API vocabulary
+
+- **CDA (Content Delivery API)**: Read-only published content delivery.
+- **CPA (Content Preview API)**: Preview/unpublished content delivery.
+- **CMA (Content Management API)**: Write and management API for content/models/settings.
+- **GraphQL Content API**: GraphQL endpoint generated from content model.
+- **Images API**: Image transformation and optimization endpoints.
+
+## Alias usage notes
+
+- Use an alias when you want stable API paths across deploys while switching the target environment.
+- In API requests, alias IDs can be used in place of environment IDs.

--- a/skills/contentful/contentful-guide/references/skill-routing.md
+++ b/skills/contentful/contentful-guide/references/skill-routing.md
@@ -1,0 +1,38 @@
+# Skill Routing
+
+Use these intent rules to choose the right skill.
+
+## Stay in `contentful-guide`
+
+Stay here when the user asks:
+
+- "What is X in Contentful?"
+- "Which API should I use?"
+- "Where are the right docs for this task?"
+- "What is the difference between space/environment/content type?"
+- "How do environment aliases work?"
+
+## Route to `$contentful-nextjs`
+
+Route when the user asks to:
+
+- add Contentful to an existing Next.js app,
+- fetch content in App Router or Pages Router,
+- set up preview with Next.js Draft Mode,
+- configure Next.js env vars and Contentful client setup.
+- implement alias-aware environment configuration in Next.js.
+
+## Route to optimization skills
+
+Route when the user asks about:
+
+- personalization, experimentation, or optimization setup,
+- Ninetailed/optimization SDK workflows,
+- troubleshooting optimization behavior.
+
+Use the appropriate optimization skill for setup, readiness, development, or diagnostics.
+
+## Notes
+
+- If user intent mixes concepts and implementation, answer conceptually in 1-3 bullets, then route.
+- If framework is not Next.js, do not force Next.js instructions; route to platform docs instead.

--- a/skills/contentful/contentful-nextjs/SKILL.md
+++ b/skills/contentful/contentful-nextjs/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: contentful-nextjs
+description: >-
+  Add and configure Contentful in an existing Next.js project. Covers installing
+  the JavaScript SDK, configuring environment variables, creating production and
+  preview-aware clients, fetching content in App Router or Pages Router, and
+  wiring Draft Mode preview flows. Use when users ask to integrate Contentful
+  with Next.js, fetch entries in Next.js, or set up preview/draft content.
+  Triggers on "add Contentful to Next.js", "Next.js Contentful setup", "Draft
+  Mode Contentful", and "Contentful App Router". Not for personalization or
+  Experiences SDK setup.
+---
+
+# Contentful Next.js
+
+Use this skill to integrate Contentful into an existing Next.js application.
+
+Contentful is a headless, API-first CMS (composable content platform) that lets Next.js apps fetch structured content through delivery and preview APIs.
+
+## Scope
+
+- Next.js App Router and Pages Router.
+- Published content delivery (CDA).
+- Preview content delivery with Draft Mode (CPA).
+- Environment variable and client setup patterns.
+- Environment alias-aware setup for stable deployment paths.
+
+## Not in scope
+
+- Personalization/optimization implementations.
+- Studio Experiences SDK setup.
+- Full content-model strategy design.
+
+## Workflow
+
+1. Confirm Next.js project structure (App Router vs Pages Router).
+2. Configure required env vars.
+3. Install and initialize `contentful` SDK.
+4. Implement published-content fetching.
+5. Add preview-aware behavior for Draft Mode.
+6. Validate with a minimal test route/page and troubleshooting checklist.
+
+## Required environment variables
+
+- `CONTENTFUL_SPACE_ID`
+- `CONTENTFUL_ACCESS_TOKEN`
+- `CONTENTFUL_PREVIEW_ACCESS_TOKEN` (for preview workflows)
+
+## Defaults
+
+- Use CDA host for normal delivery.
+- Use `preview.contentful.com` and preview token when Draft Mode is enabled.
+- Prefer an environment alias (for example `master`) as the client `environment` value to decouple runtime clients from release environment IDs.
+- Keep Contentful client creation in a shared utility module.
+
+## References
+
+- [Next.js setup](references/nextjs-setup.md)
+- [Preview and Draft Mode](references/preview-and-draft-mode.md)
+- [Troubleshooting](references/troubleshooting.md)

--- a/skills/contentful/contentful-nextjs/package.json
+++ b/skills/contentful/contentful-nextjs/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@contentful/skill-contentful-nextjs",
+  "version": "0.0.0",
+  "description": "Integrate Contentful with Next.js including draft preview flows",
+  "license": "MIT",
+  "files": ["SKILL.md", "references/**"]
+}

--- a/skills/contentful/contentful-nextjs/references/nextjs-setup.md
+++ b/skills/contentful/contentful-nextjs/references/nextjs-setup.md
@@ -1,0 +1,69 @@
+# Next.js Setup
+
+Use this as the baseline setup for adding Contentful to an existing Next.js project.
+
+## 1) Install SDK
+
+```bash
+npm install contentful
+```
+
+## 2) Configure environment variables
+
+Add to `.env.local`:
+
+```bash
+CONTENTFUL_SPACE_ID=your_space_id
+CONTENTFUL_ACCESS_TOKEN=your_cda_access_token
+CONTENTFUL_PREVIEW_ACCESS_TOKEN=your_cpa_access_token
+CONTENTFUL_ENVIRONMENT_ALIAS=master
+# optional fallback if alias is not used
+CONTENTFUL_ENVIRONMENT_ID=master
+```
+
+Get values in Contentful at **Settings -> API keys**.
+
+## 3) Create a shared client factory
+
+```ts
+// lib/contentful/client.ts
+import { createClient } from "contentful";
+
+export function createContentfulClient(preview = false) {
+  return createClient({
+    space: process.env.CONTENTFUL_SPACE_ID as string,
+    environment:
+      process.env.CONTENTFUL_ENVIRONMENT_ALIAS ||
+      process.env.CONTENTFUL_ENVIRONMENT_ID ||
+      "master",
+    accessToken: preview
+      ? (process.env.CONTENTFUL_PREVIEW_ACCESS_TOKEN as string)
+      : (process.env.CONTENTFUL_ACCESS_TOKEN as string),
+    host: preview ? "preview.contentful.com" : undefined,
+  });
+}
+```
+
+## 4) Query entries in server context
+
+```ts
+// lib/contentful/queries.ts
+import { createContentfulClient } from "./client";
+
+export async function getEntryById(entryId: string, preview = false) {
+  const client = createContentfulClient(preview);
+  return client.getEntry(entryId);
+}
+```
+
+For production content, call with `preview = false`.
+
+## 5) Keep tokens server-side
+
+- Do not expose delivery/preview tokens in browser bundles.
+- Fetch from server components, route handlers, or API routes.
+
+## 6) Prefer aliases for deployments
+
+- Point clients to an alias (for example `master`) instead of hardcoding release environment IDs.
+- Switch alias targets during rollout/rollback without changing application config.

--- a/skills/contentful/contentful-nextjs/references/preview-and-draft-mode.md
+++ b/skills/contentful/contentful-nextjs/references/preview-and-draft-mode.md
@@ -1,0 +1,49 @@
+# Preview and Draft Mode
+
+Use this pattern when editors need to preview unpublished content in Next.js.
+
+## Core approach
+
+1. Enable a route handler that turns on Next.js Draft Mode.
+2. Detect Draft Mode state in the request lifecycle.
+3. When enabled, switch to preview token + preview host.
+4. Disable cache for preview requests where required.
+
+## Environment alias pattern
+
+- Keep the client `environment` set to a stable alias (for example `master`).
+- Move alias targets between release environments to control rollout/rollback.
+- Ensure API keys have access to the alias/target used by your preview and delivery flows.
+
+## App Router pattern
+
+```ts
+// app/blog/[slug]/page.tsx
+import { draftMode } from "next/headers";
+import { getEntryById } from "@/lib/contentful/queries";
+
+export default async function Page({ params }: { params: { slug: string } }) {
+  const { isEnabled } = draftMode();
+  const entry = await getEntryById(params.slug, isEnabled);
+  return <main>{entry?.fields?.title as string}</main>;
+}
+```
+
+## Preview-aware GraphQL guidance
+
+If using GraphQL:
+
+- pass a `preview` argument in the query when Draft Mode is on,
+- use preview access token in Draft Mode,
+- disable cache in preview mode.
+
+## Vercel toolkit guidance
+
+When hosted on Vercel, use the official Vercel/Next.js guidance and toolkit route handlers for draft activation.
+
+## Requested canonical references
+
+- `https://www.contentful.com/developers/docs/tools/vercel/content-source-maps-with-vercel/`
+- `https://www.contentful.com/developers/docs/tools/vercel/vercel-nextjs/`
+- `https://www.contentful.com/developers/docs/tools/vercel/vercel-nextjs/using-draft-mode-to-fetch-unpublished-content-from-contentfuls-apis/`
+- `https://www.contentful.com/developers/docs/concepts/environment-aliases/`

--- a/skills/contentful/contentful-nextjs/references/troubleshooting.md
+++ b/skills/contentful/contentful-nextjs/references/troubleshooting.md
@@ -1,0 +1,44 @@
+# Troubleshooting
+
+## Preview content not appearing
+
+- Verify `CONTENTFUL_PREVIEW_ACCESS_TOKEN` is set and non-empty.
+- Ensure preview host is `preview.contentful.com` when Draft Mode is enabled.
+- Ensure Draft Mode is actually enabled for the request.
+
+## Published content appears in preview
+
+- Check token switch logic (`preview ? PREVIEW_TOKEN : DELIVERY_TOKEN`).
+- Check host switch logic (`preview ? "preview.contentful.com" : default`).
+- Confirm query-level `preview` argument is used for GraphQL flows.
+
+## Caching issues in preview
+
+- Use non-cached fetch behavior for preview mode.
+- Verify any framework-level cache layer is bypassed for Draft Mode requests.
+
+## API auth errors
+
+- Confirm space ID and token match the same space.
+- Confirm token has access to the target environment.
+- Prefer `Authorization: Bearer ...` over query-string token usage.
+
+## Alias-related issues
+
+- Verify `CONTENTFUL_ENVIRONMENT_ALIAS` points to an existing alias.
+- Confirm the alias target is the expected environment for this deploy.
+- If alias is not used, verify `CONTENTFUL_ENVIRONMENT_ID` matches intended environment.
+- Confirm API key access includes the alias/target environment.
+
+## Content Source Maps considerations
+
+- Source maps are for preview-oriented authoring experiences.
+- Hidden metadata can affect some string-like usages (for example URL-like or date-like values).
+- If needed, decode/clean enhanced strings per SDK guidance.
+
+## References
+
+- `https://www.contentful.com/developers/docs/concepts/environment-aliases/`
+- `https://www.contentful.com/developers/docs/tools/vercel/content-source-maps-with-vercel/`
+- `https://www.contentful.com/developers/docs/tools/vercel/vercel-nextjs/`
+- `https://www.contentful.com/developers/docs/tools/vercel/vercel-nextjs/using-draft-mode-to-fetch-unpublished-content-from-contentfuls-apis/`


### PR DESCRIPTION
## Summary
- add a new `contentful-guide` skill for Contentful basics, API selection, documentation routing, and skill routing
- add a new `contentful-nextjs` skill for integrating Contentful into Next.js with delivery, preview, Draft Mode, Content Source Maps, and environment alias guidance
- update the README skill catalog and validate discoverability with `npx skills add . --list --full-depth`

## Validation
- `npx skills add . --list --full-depth`

## Jira
- NT-2983
- Epic: NT-2946