### PR TITLE
feat(contentful): add contentful-migration skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ npx skills add contentful/skills
 |-------|----------|--------|
 | **contentful-guide** | "Contentful 101", "which Contentful API should I use", "which skill should I use" | Coming soon |
 | **contentful-nextjs** | "add Contentful to Next.js", "Next.js Contentful setup", "Draft Mode Contentful" | Coming soon |
+| **contentful-migration** | "write a migration", "create content type", "schema migration" | Coming soon |
 
 ### Optimization
 

--- a/skills/contentful/contentful-migration/SKILL.md
+++ b/skills/contentful/contentful-migration/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: contentful-migration
+description: >-
+  Write and run Contentful content model migration scripts using the
+  contentful-migration CLI and library. Covers creating, editing, and deleting
+  content types and fields, field types and validations, editor interface
+  configuration, editor layouts, sidebar widgets, entry transformations, tags,
+  annotations, and the migration context object. Use when asked to write a
+  migration, create a content type, add or modify fields, change a content model,
+  transform entries, derive linked entries, configure editor controls, or run a
+  migration script. Triggers on "contentful-migration", "schema migration",
+  "space migration", "content model migration", "field validation", "editor
+  interface", "field control", "moveField", "changeFieldId", "write a migration",
+  "create content type", "add field to content type". Not for SDK client setup
+  or Next.js integration — use $contentful-nextjs. Not for Contentful terminology
+  or API routing — use $contentful-guide.
+license: MIT
+---
+
+# Contentful Migration
+
+The `contentful-migration` tool lets you describe and execute content model changes as code. Migrations are TypeScript scripts that create, edit, or delete content types, fields, editor interfaces, and entries.
+
+**Install:**
+
+```bash
+npm install contentful-migration
+```
+
+GitHub: https://github.com/contentful/contentful-migration
+
+## Scope
+
+This skill covers:
+- Content type and field CRUD operations
+- Field types, validations, and editor interface configuration
+- Entry transformations (in-place transforms, deriving linked entries, cross-type transforms)
+- Tags, annotations, taxonomy validations
+- Editor layouts, sidebar widgets
+- Running migrations via CLI and programmatic API
+
+Not covered: SDK client setup ($contentful-nextjs), Contentful concepts and API routing ($contentful-guide).
+
+## Migration Script Format
+
+Every migration file exports a function that receives a `migration` object:
+
+```typescript
+import type { MigrationFunction } from 'contentful-migration'
+
+const migration: MigrationFunction = (migration) => {
+  const blogPost = migration.createContentType('blogPost', {
+    name: 'Blog Post',
+    description: 'A blog post entry',
+    displayField: 'title',
+  })
+
+  blogPost.createField('title')
+    .name('Title')
+    .type('Symbol')
+    .required(true)
+}
+
+export = migration
+```
+
+The function also receives a `context` object as its second parameter, providing `makeRequest` (direct CMA access), `spaceId`, and `accessToken`. Use `makeRequest` when you need data not available through the migration API.
+
+## Workflow
+
+When writing a migration:
+
+1. **Assess the change.** Identify which content types and fields need to change. Check the current content model in the Contentful web app or via CMA.
+2. **Write the migration script.** Use the operations below. Prefer chaining over object notation — it gives better error messages with line numbers.
+3. **Test in a sandbox environment.** Never run untested migrations against production. Create a sandbox environment first: `contentful environment create --name sandbox --source master`.
+4. **Run the migration.** See [Running Migrations](references/running-migrations.md) for CLI and programmatic options.
+5. **Verify.** Check the content model in the web app. Confirm entries are intact.
+
+## Content Type Operations
+
+**Create a content type:**
+
+```typescript
+const page = migration.createContentType('page', {
+  name: 'Page',
+  description: 'A generic page',
+  displayField: 'title',
+})
+```
+
+**Edit an existing content type:**
+
+```typescript
+const page = migration.editContentType('page')
+page.description('Updated description')
+page.displayField('internalName')
+```
+
+**Delete a content type:**
+
+```typescript
+migration.deleteContentType('page')
+```
+
+Content type must have zero entries before deletion. Delete all entries first, or use `transformEntriesToType` to move them.
+
+## Field Operations
+
+**Create a field:**
+
+```typescript
+page.createField('title')
+  .name('Title')
+  .type('Symbol')
+  .required(true)
+  .localized(true)
+```
+
+**Edit an existing field:**
+
+```typescript
+page.editField('title')
+  .name('Page Title')
+  .required(false)
+```
+
+**Delete a field:**
+
+```typescript
+page.deleteField('legacyField')
+```
+
+Deleting a field permanently removes its content from all entries.
+
+**Change a field ID:**
+
+```typescript
+page.changeFieldId('oldName', 'newName')
+```
+
+Existing content is preserved — only the ID changes.
+
+**Move a field:**
+
+```typescript
+page.moveField('slug').afterField('title')
+page.moveField('featured').toTheTop()
+page.moveField('metadata').toTheBottom()
+page.moveField('author').beforeField('publishDate')
+```
+
+## Field Types Quick Reference
+
+| Type | Description | Extra config |
+|------|-------------|--------------|
+| `Symbol` | Short text (max 256 chars) | — |
+| `Text` | Long text (max 50,000 chars) | — |
+| `Integer` | Whole number | — |
+| `Number` | Decimal number | — |
+| `Date` | ISO 8601 date/time | — |
+| `Boolean` | True/false | — |
+| `Object` | Arbitrary JSON | — |
+| `Location` | Lat/lon coordinates | — |
+| `RichText` | Structured rich text | `enabledNodeTypes`, `enabledMarks` validations |
+| `Array` | List of values or references | Requires `items`: `{ type, linkType?, validations? }` |
+| `Link` | Single reference | Requires `linkType`: `'Asset'` or `'Entry'` |
+| `ResourceLink` | Cross-space reference | Requires `allowedResources` |
+
+See [API Reference — Field Types](references/api-reference.md#field-types) for full configuration details.
+
+## Validations Quick Reference
+
+| Validation | Applies to | Example |
+|------------|-----------|---------|
+| `in` | Symbol, Integer, Number | `{ in: ['draft', 'published', 'archived'] }` |
+| `unique` | Symbol, Integer, Number | `{ unique: true }` |
+| `size` | Array, Text, Symbol | `{ size: { min: 1, max: 5 } }` |
+| `range` | Integer, Number | `{ range: { min: 0, max: 100 } }` |
+| `regexp` | Symbol, Text | `{ regexp: { pattern: '^[a-z0-9-]+$' } }` |
+| `dateRange` | Date | `{ dateRange: { min: '2020-01-01', max: '2030-12-31' } }` |
+| `linkContentType` | Link, Array of Links | `{ linkContentType: ['author', 'organization'] }` |
+| `linkMimetypeGroup` | Link (Asset) | `{ linkMimetypeGroup: ['image', 'video'] }` |
+| `assetFileSize` | Link (Asset) | `{ assetFileSize: { min: 0, max: 5242880 } }` |
+| `assetImageDimensions` | Link (Asset) | `{ assetImageDimensions: { width: { min: 100, max: 2000 } } }` |
+
+Apply validations via `.validations([...])` on a field. See [API Reference — Validations](references/api-reference.md#validations) for all options.
+
+## Entry Transformations
+
+**Transform entries in place:**
+
+```typescript
+migration.transformEntries({
+  contentType: 'blogPost',
+  from: ['firstName', 'lastName'],
+  to: ['fullName'],
+  transformEntryForLocale: (fields, locale) => {
+    const first = fields.firstName[locale]
+    const last = fields.lastName[locale]
+    if (!first && !last) return
+    return { fullName: `${first || ''} ${last || ''}`.trim() }
+  },
+})
+```
+
+Options: `shouldPublish` (`true`, `false`, or `'preserve'` — default `'preserve'`).
+
+**Derive linked entries:**
+
+```typescript
+migration.deriveLinkedEntries({
+  contentType: 'blogPost',
+  derivedContentType: 'author',
+  from: ['authorName'],
+  toReferenceField: 'authorRef',
+  derivedFields: ['name'],
+  identityKey: (fields) =>
+    fields.authorName['en-US'].toLowerCase().replace(/\s+/g, '-'),
+  deriveEntryForLocale: (fields, locale) => {
+    if (locale !== 'en-US') return
+    return { name: fields.authorName[locale] }
+  },
+})
+```
+
+This creates new `author` entries from existing `blogPost.authorName` data and links them via `authorRef`.
+
+See [Patterns — Transform Entries](references/patterns.md#transform-entries) and [Patterns — Derive Linked Entries](references/patterns.md#derive-linked-entries) for more examples.
+
+## Editor Interface
+
+**Change the widget for a field:**
+
+```typescript
+const page = migration.editContentType('page')
+
+page.changeFieldControl('slug', 'builtin', 'slugEditor', {
+  helpText: 'URL-friendly identifier',
+  trackingFieldId: 'title',
+})
+
+page.changeFieldControl('category', 'builtin', 'dropdown')
+page.changeFieldControl('publishDate', 'builtin', 'datePicker', { format: 'dateonly' })
+```
+
+Widget namespaces: `builtin`, `extension` (UI extensions), `app` (custom apps).
+
+See [API Reference — Editor Interface](references/api-reference.md#editor-interface) for all built-in widgets and their settings.
+
+## Best Practices
+
+1. **Number migration files sequentially:** `001-create-blog-post.ts`, `002-add-author-field.ts`, `003-transform-categories.ts`.
+2. **One logical change per migration.** Easier to debug, revert, and review.
+3. **Always test in a sandbox environment** before running against production.
+4. **Use `shouldPublish: 'preserve'`** (the default) to maintain existing publish states during transforms.
+5. **Prefer chaining over object notation** — chaining gives line-level error messages.
+6. **Split data transforms from schema changes.** First migration changes the schema, second transforms data. This makes each step independently verifiable.
+7. **Use `context.makeRequest`** sparingly — only when the migration API doesn't cover your use case.
+
+## Common Mistakes
+
+- **Forgetting `items` on Array fields.** `type: 'Array'` requires an `items` property specifying the element type.
+- **Deleting a content type with entries.** You must delete all entries first, or move them with `transformEntriesToType`.
+- **Missing `linkType` on Link fields.** `type: 'Link'` requires `linkType: 'Asset'` or `linkType: 'Entry'`.
+- **Running against master.** Always test in a sandbox environment. Use `--environment-id sandbox` on the CLI.
+- **Not handling missing locales in transforms.** `transformEntryForLocale` is called for every locale — return `undefined` to skip.
+- **Setting `displayField` to a non-Symbol field.** The display field must be of type `Symbol`.
+
+## References
+
+- [API Reference](references/api-reference.md) — complete migration API surface
+- [Patterns](references/patterns.md) — common migration examples
+- [Running Migrations](references/running-migrations.md) — CLI, programmatic API, CI/CD
+
+## Related Skills
+
+- $contentful-guide — Contentful concepts, terminology, API routing
+- $contentful-nextjs — Next.js integration with Contentful

--- a/skills/contentful/contentful-migration/package.json
+++ b/skills/contentful/contentful-migration/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@contentful/skill-contentful-migration",
+  "version": "0.0.0",
+  "description": "Write and run Contentful content model migration scripts",
+  "license": "MIT",
+  "files": ["SKILL.md", "references/**"]
+}

--- a/skills/contentful/contentful-migration/references/api-reference.md
+++ b/skills/contentful/contentful-migration/references/api-reference.md
@@ -1,0 +1,574 @@
+# Migration API Reference
+
+Complete reference for the `contentful-migration` library API.
+
+## Table of Contents
+
+- [Content Type Operations](#content-type-operations)
+- [Field Operations](#field-operations)
+- [Field Types](#field-types)
+- [Validations](#validations)
+- [Editor Interface](#editor-interface)
+- [Editor Layouts](#editor-layouts)
+- [Sidebar Widgets](#sidebar-widgets)
+- [Tags](#tags)
+- [Annotations](#annotations)
+- [Taxonomy Validations](#taxonomy-validations)
+- [Context Object](#context-object)
+
+## Content Type Operations
+
+### `migration.createContentType(id[, opts])`
+
+Creates a new content type. Returns a `ContentType` object for chaining.
+
+Options (also available as chained methods):
+- `name` (string) — display name
+- `description` (string) — description
+- `displayField` (string) — field ID used as the entry title (must be a Symbol field)
+
+```typescript
+const post = migration.createContentType('post')
+  .name('Post')
+  .description('Blog post')
+  .displayField('title')
+```
+
+### `migration.editContentType(id[, opts])`
+
+Returns an existing content type for modification. Same options as `createContentType`.
+
+### `migration.deleteContentType(id)`
+
+Deletes a content type. The type must have zero published or draft entries.
+
+## Field Operations
+
+All field methods are called on a `ContentType` object.
+
+### `contentType.createField(id[, opts])`
+
+Creates a field. Returns a `Field` object for chaining.
+
+Options (also available as chained methods):
+- `name` (string, required) — display name
+- `type` (string, required) — field type
+- `required` (boolean) — marks as required
+- `localized` (boolean) — enables per-locale values
+- `disabled` (boolean) — prevents editing in the web app
+- `omitted` (boolean) — field is not included in API responses
+- `defaultValue` (object) — locale-keyed defaults: `{ 'en-US': 'value' }`
+- `validations` (array) — validation rules
+- `items` (object) — for Array type: `{ type, linkType?, validations? }`
+- `linkType` (string) — for Link type: `'Asset'` or `'Entry'`
+- `allowedResources` (array) — for ResourceLink type
+
+### `contentType.editField(id[, opts])`
+
+Edits an existing field. Same options as `createField`.
+
+### `contentType.deleteField(id)`
+
+Deletes a field and its content from all entries. This is irreversible.
+
+### `contentType.changeFieldId(currentId, newId)`
+
+Renames a field ID. Content is preserved.
+
+### `contentType.moveField(id)`
+
+Returns a `Movement` object:
+- `.toTheTop()` — move to first position
+- `.toTheBottom()` — move to last position
+- `.beforeField(fieldId)` — position before another field
+- `.afterField(fieldId)` — position after another field
+
+## Field Types
+
+### Symbol
+
+Short text, max 256 characters. Used for titles, slugs, short strings.
+
+```typescript
+field.type('Symbol')
+```
+
+### Text
+
+Long text, max 50,000 characters. Used for descriptions, body text (plain text).
+
+```typescript
+field.type('Text')
+```
+
+### Integer
+
+Whole number.
+
+```typescript
+field.type('Integer')
+```
+
+### Number
+
+Decimal number (floating point).
+
+```typescript
+field.type('Number')
+```
+
+### Date
+
+ISO 8601 date/time string.
+
+```typescript
+field.type('Date')
+```
+
+### Boolean
+
+True or false.
+
+```typescript
+field.type('Boolean')
+```
+
+### Object
+
+Arbitrary JSON object. Useful for structured metadata.
+
+```typescript
+field.type('Object')
+```
+
+### Location
+
+Geographic coordinates (latitude/longitude).
+
+```typescript
+field.type('Location')
+```
+
+### RichText
+
+Structured rich text with embedded entries and assets. Configure allowed node types and marks via validations:
+
+```typescript
+field.type('RichText').validations([
+  {
+    enabledNodeTypes: [
+      'heading-1', 'heading-2', 'heading-3',
+      'ordered-list', 'unordered-list',
+      'blockquote', 'hyperlink',
+      'embedded-entry-block', 'embedded-asset-block',
+    ],
+  },
+  {
+    enabledMarks: ['bold', 'italic', 'underline', 'code'],
+  },
+])
+```
+
+Available node types: `heading-1` through `heading-6`, `ordered-list`, `unordered-list`, `blockquote`, `hr`, `hyperlink`, `entry-hyperlink`, `asset-hyperlink`, `embedded-entry-block`, `embedded-asset-block`, `embedded-entry-inline`, `table`.
+
+Available marks: `bold`, `italic`, `underline`, `code`, `superscript`, `subscript`.
+
+### Array
+
+List of values or references. Requires `items` configuration:
+
+```typescript
+// Array of symbols
+field.type('Array').items({ type: 'Symbol' })
+
+// Array of entry references
+field.type('Array').items({
+  type: 'Link',
+  linkType: 'Entry',
+  validations: [{ linkContentType: ['tag', 'category'] }],
+})
+
+// Array of asset references
+field.type('Array').items({
+  type: 'Link',
+  linkType: 'Asset',
+  validations: [{ linkMimetypeGroup: ['image'] }],
+})
+```
+
+### Link
+
+Single reference to an entry or asset. Requires `linkType`:
+
+```typescript
+// Entry reference
+field.type('Link').linkType('Entry')
+  .validations([{ linkContentType: ['author'] }])
+
+// Asset reference
+field.type('Link').linkType('Asset')
+  .validations([{ linkMimetypeGroup: ['image', 'video'] }])
+```
+
+### ResourceLink
+
+Cross-space reference. Requires `allowedResources`:
+
+```typescript
+field.type('ResourceLink').allowedResources([{
+  type: 'Contentful:Entry',
+  source: 'crn:contentful:::content:spaces/other-space-id',
+  contentTypes: ['article'],
+}])
+```
+
+## Validations
+
+Apply validations with `.validations([...])` on a field. Multiple validations can be combined in one array.
+
+### `in`
+
+Restricts to a set of allowed values. Works with Symbol, Integer, Number.
+
+```typescript
+field.validations([{ in: ['draft', 'review', 'published'] }])
+```
+
+### `unique`
+
+Ensures values are unique across all entries at publication time.
+
+```typescript
+field.validations([{ unique: true }])
+```
+
+### `size`
+
+Min/max constraint on length (text) or count (array).
+
+```typescript
+field.validations([{ size: { min: 1, max: 10 } }])
+```
+
+### `range`
+
+Min/max for numeric values.
+
+```typescript
+field.validations([{ range: { min: 0, max: 100 } }])
+```
+
+### `regexp`
+
+Regular expression pattern match.
+
+```typescript
+field.validations([{ regexp: { pattern: '^[a-z0-9-]+$', flags: 'i' } }])
+```
+
+### `dateRange`
+
+Min/max date constraint.
+
+```typescript
+field.validations([{ dateRange: { min: '2020-01-01T00:00:00Z', max: '2030-12-31T23:59:59Z' } }])
+```
+
+### `linkContentType`
+
+Restricts which content types a Link or Array of Links can reference.
+
+```typescript
+field.validations([{ linkContentType: ['author', 'organization'] }])
+```
+
+### `linkMimetypeGroup`
+
+Restricts asset MIME types. Groups: `attachment`, `plaintext`, `image`, `audio`, `video`, `richtext`, `presentation`, `spreadsheet`, `pdfdocument`, `archive`, `code`, `markup`.
+
+```typescript
+field.validations([{ linkMimetypeGroup: ['image', 'video'] }])
+```
+
+### `assetFileSize`
+
+Min/max file size in bytes.
+
+```typescript
+field.validations([{ assetFileSize: { min: 0, max: 5242880 } }]) // max 5 MB
+```
+
+### `assetImageDimensions`
+
+Min/max width/height in pixels.
+
+```typescript
+field.validations([{
+  assetImageDimensions: {
+    width: { min: 100, max: 4000 },
+    height: { min: 100, max: 4000 },
+  },
+}])
+```
+
+## Editor Interface
+
+### `contentType.changeFieldControl(fieldId, widgetNamespace, widgetId[, settings])`
+
+Sets the UI widget for a field.
+
+**Widget namespaces:**
+- `builtin` — standard Contentful widgets
+- `extension` — UI extensions (installed separately)
+- `app` — custom Contentful apps
+
+### Built-in Widgets
+
+| Widget ID | Field types | Settings |
+|-----------|-------------|----------|
+| `singleLine` | Symbol | `helpText` |
+| `urlEditor` | Symbol | `helpText` |
+| `slugEditor` | Symbol | `helpText`, `trackingFieldId` |
+| `dropdown` | Symbol, Integer, Number | `helpText` |
+| `radio` | Symbol, Integer, Number | `helpText` |
+| `tagEditor` | Symbol (Array) | `helpText` |
+| `listInput` | Symbol (Array) | `helpText` |
+| `checkbox` | Symbol (Array) | `helpText` |
+| `multipleLine` | Text | `helpText` |
+| `markdown` | Text | `helpText` |
+| `richTextEditor` | RichText | `helpText` |
+| `numberEditor` | Integer, Number | `helpText` |
+| `rating` | Integer, Number | `helpText`, `stars` (default: 5) |
+| `boolean` | Boolean | `helpText`, `trueLabel`, `falseLabel` |
+| `datePicker` | Date | `helpText`, `format` (`dateonly`, `time`, `timeZ`), `ampm` (`12`, `24`) |
+| `locationEditor` | Location | `helpText` |
+| `objectEditor` | Object | `helpText` |
+| `entryLinkEditor` | Link (Entry) | `helpText`, `showCreateEntityAction`, `showLinkEntityAction` |
+| `entryLinksEditor` | Array (Entry) | `helpText`, `bulkEditing`, `showCreateEntityAction`, `showLinkEntityAction` |
+| `entryCardEditor` | Link (Entry) | `helpText`, `showCreateEntityAction`, `showLinkEntityAction` |
+| `entryCardsEditor` | Array (Entry) | `helpText`, `bulkEditing`, `showCreateEntityAction`, `showLinkEntityAction` |
+| `assetLinkEditor` | Link (Asset) | `helpText`, `showCreateEntityAction`, `showLinkEntityAction` |
+| `assetLinksEditor` | Array (Asset) | `helpText`, `showCreateEntityAction`, `showLinkEntityAction` |
+| `assetGalleryEditor` | Array (Asset) | `helpText` |
+
+### `contentType.resetFieldControl(fieldId)`
+
+Resets a field to its default widget.
+
+### `contentType.copyFieldControl(sourceFieldId, destinationFieldId)`
+
+Copies widget settings from one field to another.
+
+## Editor Layouts
+
+Editor layouts let you organize fields into tabs and collapsible sections.
+
+### `contentType.createEditorLayout()`
+
+Creates an editor layout. Returns an `EditorLayout` object.
+
+### `editorLayout.createFieldGroup(id[, opts])`
+
+Creates a field group (tab or section). Options: `name` (string).
+
+### `editorLayout.editFieldGroup(id[, opts])`
+
+Edits an existing field group.
+
+### `editorLayout.deleteFieldGroup(id)`
+
+Deletes a field group.
+
+### `editorLayout.changeFieldGroupId(currentId, newId)`
+
+Renames a field group.
+
+### `editorLayout.changeFieldGroupControl(groupId, widgetNamespace, widgetId[, settings])`
+
+Configures how a field group renders.
+
+**Built-in group widgets:**
+- `topLevelTab` — renders as a tab. Settings: `helpText`.
+- `fieldset` — renders as a collapsible section. Settings: `helpText`, `collapsible` (boolean), `collapsedByDefault` (boolean).
+
+### Moving Fields in Layouts
+
+`editorLayout.moveField(fieldId)` returns an `EditorLayoutMovement` with:
+- `.toTheTopOfFieldGroup(groupId?)` — move to top of group
+- `.toTheBottomOfFieldGroup(groupId?)` — move to bottom of group
+- `.beforeField(fieldId)` — before a specific field
+- `.afterField(fieldId)` — after a specific field
+- `.beforeFieldGroup(groupId)` — before a field group
+- `.afterFieldGroup(groupId)` — after a field group
+
+```typescript
+const layout = page.createEditorLayout()
+
+layout.createFieldGroup('content', { name: 'Content' })
+layout.changeFieldGroupControl('content', 'builtin', 'topLevelTab')
+
+layout.createFieldGroup('seo', { name: 'SEO' })
+layout.changeFieldGroupControl('seo', 'builtin', 'topLevelTab')
+
+layout.createFieldGroup('openGraph', { name: 'Open Graph' })
+layout.changeFieldGroupControl('openGraph', 'builtin', 'fieldset', {
+  helpText: 'Social sharing metadata',
+  collapsedByDefault: true,
+})
+
+layout.moveField('title').toTheTopOfFieldGroup('content')
+layout.moveField('body').afterField('title')
+layout.moveField('metaTitle').toTheTopOfFieldGroup('seo')
+layout.moveField('ogImage').toTheTopOfFieldGroup('openGraph')
+```
+
+## Sidebar Widgets
+
+### `contentType.addSidebarWidget(widgetNamespace, widgetId[, settings, insertBeforeWidgetId])`
+
+Adds a widget to the sidebar. Widget namespaces: `sidebar-builtin`, `extension`.
+
+### `contentType.updateSidebarWidget(widgetNamespace, widgetId, settings)`
+
+Updates an existing sidebar widget's settings.
+
+### `contentType.removeSidebarWidget(widgetNamespace, widgetId)`
+
+Removes a widget from the sidebar.
+
+### `contentType.resetSidebarToDefault()`
+
+Resets sidebar to default configuration.
+
+```typescript
+const page = migration.editContentType('page')
+page.addSidebarWidget('sidebar-builtin', 'publication-widget')
+page.addSidebarWidget('extension', 'translationExtension', {
+  sourceLocale: 'en-US',
+})
+page.removeSidebarWidget('sidebar-builtin', 'versions-widget')
+```
+
+## Tags
+
+### `migration.createTag(id[, opts, visibility])`
+
+Creates a tag. Options: `name` (string). Visibility: `'public'` (default) or `'private'`.
+
+### `migration.editTag(id[, opts])`
+
+Edits an existing tag.
+
+### `migration.deleteTag(id)`
+
+Deletes a tag. Works even if the tag is attached to entries or assets.
+
+### `migration.setTagsForEntries(config)`
+
+Assigns tags to entries based on field values.
+
+- `contentType` (required) — content type ID
+- `from` (required) — array of field IDs to read
+- `setTagsForEntry` (required) — `(entryFields, currentTags, allTags) => ITagLink[]`
+
+```typescript
+migration.createTag('region-eu').name('Region: EU')
+migration.createTag('region-us').name('Region: US')
+
+migration.setTagsForEntries({
+  contentType: 'office',
+  from: ['region'],
+  setTagsForEntry: (fields, currentTags, allTags) => {
+    const region = fields.region['en-US']
+    const tagId = region === 'Europe' ? 'region-eu' : 'region-us'
+    const newTag = allTags.find((t) => t.sys.id === tagId)
+    return [...currentTags, newTag!]
+  },
+})
+```
+
+## Annotations
+
+### `contentType.setAnnotations(annotationIds)`
+
+Sets annotations on a content type.
+
+Available annotations:
+- `Contentful:AggregateRoot`
+- `Contentful:AggregateComponent`
+
+### `field.setAnnotations(annotationIds[, opts])`
+
+Sets annotations on a field. Options: `parameters` (object with `appFunctionId`, `appDefinitionId`).
+
+Available field annotations:
+- `Contentful:GraphQLFieldResolver`
+
+### `contentType.clearAnnotations()` / `field.clearAnnotations()`
+
+Removes all annotations.
+
+```typescript
+const page = migration.createContentType('page')
+page.setAnnotations(['Contentful:AggregateRoot'])
+
+const computed = page.createField('computed')
+  .type('Symbol')
+  .name('Computed Value')
+computed.setAnnotations(['Contentful:GraphQLFieldResolver'], {
+  parameters: { appFunctionId: 'func-123', appDefinitionId: 'app-456' },
+})
+```
+
+## Taxonomy Validations
+
+### `contentType.addTaxonomyValidation(id, linkType[, opts])`
+
+Adds a taxonomy validation. `linkType`: `'TaxonomyConcept'` or `'TaxonomyConceptScheme'`. Options: `{ required: boolean }`.
+
+### `contentType.clearTaxonomyValidations()`
+
+Removes all taxonomy validations.
+
+### `contentType.setTaxonomyValidations(validations)`
+
+Replaces all taxonomy validations.
+
+```typescript
+const article = migration.editContentType('article')
+article.addTaxonomyValidation('topic-taxonomy', 'TaxonomyConcept', { required: true })
+article.addTaxonomyValidation('content-category', 'TaxonomyConceptScheme')
+```
+
+Taxonomy concepts and schemes must already exist (create them via the web app or CMA).
+
+## Context Object
+
+The second parameter to the migration function provides:
+
+### `context.makeRequest(config)`
+
+Direct access to the Contentful Management API. Uses Axios-style configuration.
+
+```typescript
+import type { MigrationFunction } from 'contentful-migration'
+
+const migration: MigrationFunction = async (migration, { makeRequest }) => {
+  const response = await makeRequest({
+    method: 'GET',
+    url: '/content_types?limit=100',
+  })
+
+  const contentTypes = response.items
+}
+
+export = migration
+```
+
+### `context.spaceId`
+
+The current space ID (string).
+
+### `context.accessToken`
+
+The current management access token (string).

--- a/skills/contentful/contentful-migration/references/patterns.md
+++ b/skills/contentful/contentful-migration/references/patterns.md
@@ -1,0 +1,589 @@
+# Migration Patterns
+
+Common migration patterns with complete, ready-to-use examples.
+
+## Table of Contents
+
+- [Create a Content Type with Multiple Fields](#create-a-content-type-with-multiple-fields)
+- [Add a Field to an Existing Content Type](#add-a-field-to-an-existing-content-type)
+- [Rename a Field](#rename-a-field)
+- [Change a Field Type](#change-a-field-type)
+- [Add Validations to a Field](#add-validations-to-a-field)
+- [Configure Rich Text](#configure-rich-text)
+- [Set Up Reference Fields](#set-up-reference-fields)
+- [Transform Entries](#transform-entries)
+- [Derive Linked Entries](#derive-linked-entries)
+- [Transform Entries to a Different Type](#transform-entries-to-a-different-type)
+- [Configure Editor Interface](#configure-editor-interface)
+- [Set Up Editor Layout with Tabs](#set-up-editor-layout-with-tabs)
+- [Content Type with Localized Fields](#content-type-with-localized-fields)
+- [Delete a Content Type Safely](#delete-a-content-type-safely)
+
+## Create a Content Type with Multiple Fields
+
+```typescript
+import type { MigrationFunction } from 'contentful-migration'
+
+const migration: MigrationFunction = (migration) => {
+  const blogPost = migration.createContentType('blogPost', {
+    name: 'Blog Post',
+    description: 'An article on the blog',
+    displayField: 'title',
+  })
+
+  blogPost.createField('title')
+    .name('Title')
+    .type('Symbol')
+    .required(true)
+
+  blogPost.createField('slug')
+    .name('Slug')
+    .type('Symbol')
+    .required(true)
+    .validations([
+      { unique: true },
+      { regexp: { pattern: '^[a-z0-9]+(?:-[a-z0-9]+)*$' } },
+    ])
+
+  blogPost.createField('body')
+    .name('Body')
+    .type('RichText')
+
+  blogPost.createField('author')
+    .name('Author')
+    .type('Link')
+    .linkType('Entry')
+    .required(true)
+    .validations([{ linkContentType: ['author'] }])
+
+  blogPost.createField('heroImage')
+    .name('Hero Image')
+    .type('Link')
+    .linkType('Asset')
+    .validations([
+      { linkMimetypeGroup: ['image'] },
+      { assetImageDimensions: { width: { min: 800 } } },
+    ])
+
+  blogPost.createField('tags')
+    .name('Tags')
+    .type('Array')
+    .items({
+      type: 'Link',
+      linkType: 'Entry',
+      validations: [{ linkContentType: ['tag'] }],
+    })
+
+  blogPost.createField('publishDate')
+    .name('Publish Date')
+    .type('Date')
+    .required(true)
+
+  blogPost.changeFieldControl('slug', 'builtin', 'slugEditor', {
+    trackingFieldId: 'title',
+  })
+
+  blogPost.changeFieldControl('publishDate', 'builtin', 'datePicker', {
+    format: 'dateonly',
+  })
+}
+
+export = migration
+```
+
+## Add a Field to an Existing Content Type
+
+```typescript
+import type { MigrationFunction } from 'contentful-migration'
+
+const migration: MigrationFunction = (migration) => {
+  const blogPost = migration.editContentType('blogPost')
+
+  blogPost.createField('excerpt')
+    .name('Excerpt')
+    .type('Text')
+    .validations([{ size: { max: 300 } }])
+
+  blogPost.moveField('excerpt').afterField('title')
+
+  blogPost.changeFieldControl('excerpt', 'builtin', 'multipleLine', {
+    helpText: 'Short summary for listing pages (max 300 characters)',
+  })
+}
+
+export = migration
+```
+
+## Rename a Field
+
+```typescript
+import type { MigrationFunction } from 'contentful-migration'
+
+const migration: MigrationFunction = (migration) => {
+  const page = migration.editContentType('page')
+  page.changeFieldId('headline', 'title')
+  page.editField('title').name('Title')
+}
+
+export = migration
+```
+
+Content is preserved — only the API ID changes. Update your code to use the new field ID.
+
+## Change a Field Type
+
+You cannot change a field's type directly. Instead: create a new field, transform data, then delete the old field.
+
+```typescript
+import type { MigrationFunction } from 'contentful-migration'
+
+const migration: MigrationFunction = (migration) => {
+  const article = migration.editContentType('article')
+
+  // Step 1: Create new Integer field
+  article.createField('readTimeMinutes')
+    .name('Read Time (minutes)')
+    .type('Integer')
+    .validations([{ range: { min: 1, max: 120 } }])
+
+  // Step 2: Transform data from old Symbol field to new Integer field
+  migration.transformEntries({
+    contentType: 'article',
+    from: ['readTime'],
+    to: ['readTimeMinutes'],
+    transformEntryForLocale: (fields, locale) => {
+      const raw = fields.readTime?.[locale]
+      if (!raw) return
+      const parsed = parseInt(raw, 10)
+      if (isNaN(parsed)) return
+      return { readTimeMinutes: parsed }
+    },
+  })
+
+  // Step 3: Delete old field
+  article.deleteField('readTime')
+}
+
+export = migration
+```
+
+## Add Validations to a Field
+
+```typescript
+import type { MigrationFunction } from 'contentful-migration'
+
+const migration: MigrationFunction = (migration) => {
+  const product = migration.editContentType('product')
+
+  product.editField('sku').validations([
+    { unique: true },
+    { regexp: { pattern: '^[A-Z]{2}-\\d{6}$' } },
+  ])
+
+  product.editField('price').validations([
+    { range: { min: 0 } },
+  ])
+
+  product.editField('category').validations([
+    { in: ['Electronics', 'Clothing', 'Books', 'Home', 'Food'] },
+  ])
+}
+
+export = migration
+```
+
+## Configure Rich Text
+
+```typescript
+import type { MigrationFunction } from 'contentful-migration'
+
+const migration: MigrationFunction = (migration) => {
+  const article = migration.editContentType('article')
+
+  article.createField('content')
+    .name('Content')
+    .type('RichText')
+    .validations([
+      {
+        enabledNodeTypes: [
+          'heading-2', 'heading-3', 'heading-4',
+          'ordered-list', 'unordered-list',
+          'blockquote', 'hyperlink',
+          'embedded-entry-block',
+          'embedded-asset-block',
+          'table',
+        ],
+      },
+      {
+        enabledMarks: ['bold', 'italic', 'code'],
+      },
+      {
+        nodes: {
+          'embedded-entry-block': [{
+            linkContentType: ['codeBlock', 'callout', 'imageGallery'],
+          }],
+          'embedded-entry-inline': [{
+            linkContentType: ['inlineLink'],
+          }],
+        },
+      },
+    ])
+}
+
+export = migration
+```
+
+## Set Up Reference Fields
+
+**Single reference:**
+
+```typescript
+import type { MigrationFunction } from 'contentful-migration'
+
+const migration: MigrationFunction = (migration) => {
+  const page = migration.editContentType('page')
+
+  page.createField('author')
+    .name('Author')
+    .type('Link')
+    .linkType('Entry')
+    .required(true)
+    .validations([{ linkContentType: ['person'] }])
+}
+
+export = migration
+```
+
+**Multiple allowed content types:**
+
+```typescript
+page.createField('hero')
+  .name('Hero Section')
+  .type('Link')
+  .linkType('Entry')
+  .validations([{ linkContentType: ['heroBanner', 'heroVideo', 'heroSlider'] }])
+```
+
+**Array of references:**
+
+```typescript
+page.createField('sections')
+  .name('Page Sections')
+  .type('Array')
+  .items({
+    type: 'Link',
+    linkType: 'Entry',
+    validations: [{ linkContentType: ['textBlock', 'imageBlock', 'ctaBlock'] }],
+  })
+  .validations([{ size: { min: 1, max: 20 } }])
+```
+
+## Transform Entries
+
+**Combine fields:**
+
+```typescript
+import type { MigrationFunction } from 'contentful-migration'
+
+const migration: MigrationFunction = (migration) => {
+  migration.transformEntries({
+    contentType: 'person',
+    from: ['firstName', 'lastName'],
+    to: ['fullName'],
+    transformEntryForLocale: (fields, locale) => {
+      const first = fields.firstName?.[locale] || ''
+      const last = fields.lastName?.[locale] || ''
+      if (!first && !last) return
+      return { fullName: `${first} ${last}`.trim() }
+    },
+  })
+}
+
+export = migration
+```
+
+**Split a field:**
+
+```typescript
+import type { MigrationFunction } from 'contentful-migration'
+
+const migration: MigrationFunction = (migration) => {
+  migration.transformEntries({
+    contentType: 'address',
+    from: ['fullAddress'],
+    to: ['street', 'city', 'zip'],
+    transformEntryForLocale: (fields, locale) => {
+      const address = fields.fullAddress?.[locale]
+      if (!address) return
+      const parts = address.split(', ')
+      return {
+        street: parts[0] || '',
+        city: parts[1] || '',
+        zip: parts[2] || '',
+      }
+    },
+  })
+}
+
+export = migration
+```
+
+**Conditionally update entries:**
+
+```typescript
+import type { MigrationFunction } from 'contentful-migration'
+
+const migration: MigrationFunction = (migration) => {
+  migration.transformEntries({
+    contentType: 'article',
+    from: ['status'],
+    to: ['status'],
+    transformEntryForLocale: (fields, locale) => {
+      const status = fields.status?.[locale]
+      if (status === 'draft') return { status: 'in-review' }
+      return
+    },
+    shouldPublish: 'preserve',
+  })
+}
+
+export = migration
+```
+
+## Derive Linked Entries
+
+Extract data from existing entries into new entries of a different content type, and link them.
+
+```typescript
+import type { MigrationFunction } from 'contentful-migration'
+
+const migration: MigrationFunction = (migration) => {
+  // First: create the target content type
+  const category = migration.createContentType('category', {
+    name: 'Category',
+    displayField: 'name',
+  })
+  category.createField('name').name('Name').type('Symbol').required(true)
+  category.createField('slug').name('Slug').type('Symbol').required(true)
+
+  // Second: add a reference field to the source content type
+  const article = migration.editContentType('article')
+  article.createField('categoryRef')
+    .name('Category')
+    .type('Link')
+    .linkType('Entry')
+    .validations([{ linkContentType: ['category'] }])
+
+  // Third: derive entries and link them
+  migration.deriveLinkedEntries({
+    contentType: 'article',
+    derivedContentType: 'category',
+    from: ['categoryName'],
+    toReferenceField: 'categoryRef',
+    derivedFields: ['name', 'slug'],
+    identityKey: async (fields) => {
+      return fields.categoryName['en-US']
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+    },
+    deriveEntryForLocale: async (fields, locale) => {
+      if (locale !== 'en-US') return
+      const name = fields.categoryName[locale]
+      return {
+        name,
+        slug: name.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+      }
+    },
+  })
+}
+
+export = migration
+```
+
+The `identityKey` function deduplicates: entries with the same key produce one derived entry.
+
+## Transform Entries to a Different Type
+
+Move entries from one content type to another.
+
+```typescript
+import type { MigrationFunction } from 'contentful-migration'
+
+const migration: MigrationFunction = (migration) => {
+  migration.transformEntriesToType({
+    sourceContentType: 'legacyPost',
+    targetContentType: 'article',
+    from: ['title', 'body', 'author'],
+    identityKey: (fields) =>
+      fields.title['en-US'].toLowerCase().replace(/\s+/g, '-'),
+    transformEntryForLocale: (fields, locale) => ({
+      title: fields.title?.[locale],
+      content: fields.body?.[locale],
+      authorName: fields.author?.[locale],
+    }),
+    updateReferences: true,
+    removeOldEntries: true,
+    shouldPublish: 'preserve',
+  })
+}
+
+export = migration
+```
+
+Options:
+- `updateReferences` — updates Link fields pointing to old entries (does not support RichText references)
+- `removeOldEntries` — deletes source entries after transform
+- `entryIds` — limit to specific entry IDs
+
+## Configure Editor Interface
+
+```typescript
+import type { MigrationFunction } from 'contentful-migration'
+
+const migration: MigrationFunction = (migration) => {
+  const page = migration.editContentType('page')
+
+  page.changeFieldControl('title', 'builtin', 'singleLine', {
+    helpText: 'The page title shown in the browser tab',
+  })
+
+  page.changeFieldControl('slug', 'builtin', 'slugEditor', {
+    trackingFieldId: 'title',
+    helpText: 'URL path segment (auto-generated from title)',
+  })
+
+  page.changeFieldControl('status', 'builtin', 'dropdown')
+
+  page.changeFieldControl('featured', 'builtin', 'boolean', {
+    trueLabel: 'Featured',
+    falseLabel: 'Not featured',
+  })
+
+  page.changeFieldControl('priority', 'builtin', 'rating', { stars: 5 })
+
+  page.changeFieldControl('publishDate', 'builtin', 'datePicker', {
+    format: 'dateonly',
+    ampm: '24',
+  })
+}
+
+export = migration
+```
+
+## Set Up Editor Layout with Tabs
+
+```typescript
+import type { MigrationFunction } from 'contentful-migration'
+
+const migration: MigrationFunction = (migration) => {
+  const page = migration.editContentType('page')
+
+  const layout = page.createEditorLayout()
+
+  // Create tabs
+  layout.createFieldGroup('content', { name: 'Content' })
+  layout.changeFieldGroupControl('content', 'builtin', 'topLevelTab')
+
+  layout.createFieldGroup('media', { name: 'Media' })
+  layout.changeFieldGroupControl('media', 'builtin', 'topLevelTab')
+
+  layout.createFieldGroup('seo', { name: 'SEO' })
+  layout.changeFieldGroupControl('seo', 'builtin', 'topLevelTab')
+
+  // Create a collapsible section inside the SEO tab
+  layout.createFieldGroup('openGraph', { name: 'Open Graph' })
+  layout.changeFieldGroupControl('openGraph', 'builtin', 'fieldset', {
+    helpText: 'Social sharing metadata',
+    collapsedByDefault: true,
+  })
+
+  // Move fields into tabs
+  layout.moveField('title').toTheTopOfFieldGroup('content')
+  layout.moveField('body').afterField('title')
+
+  layout.moveField('heroImage').toTheTopOfFieldGroup('media')
+  layout.moveField('gallery').afterField('heroImage')
+
+  layout.moveField('metaTitle').toTheTopOfFieldGroup('seo')
+  layout.moveField('metaDescription').afterField('metaTitle')
+  layout.moveField('ogTitle').toTheTopOfFieldGroup('openGraph')
+  layout.moveField('ogImage').afterField('ogTitle')
+}
+
+export = migration
+```
+
+## Content Type with Localized Fields
+
+```typescript
+import type { MigrationFunction } from 'contentful-migration'
+
+const migration: MigrationFunction = (migration) => {
+  const product = migration.createContentType('product', {
+    name: 'Product',
+    displayField: 'name',
+  })
+
+  // Localized fields — different value per locale
+  product.createField('name')
+    .name('Name')
+    .type('Symbol')
+    .required(true)
+    .localized(true)
+
+  product.createField('description')
+    .name('Description')
+    .type('Text')
+    .localized(true)
+
+  // Non-localized fields — same value across all locales
+  product.createField('sku')
+    .name('SKU')
+    .type('Symbol')
+    .required(true)
+    .validations([{ unique: true }])
+
+  product.createField('price')
+    .name('Price')
+    .type('Number')
+    .required(true)
+}
+
+export = migration
+```
+
+## Delete a Content Type Safely
+
+Deleting a content type requires removing all entries and inbound references first.
+
+```typescript
+import type { MigrationFunction } from 'contentful-migration'
+
+const migration: MigrationFunction = async (migration, { makeRequest }) => {
+  // Step 1: Check for entries (optional safety check)
+  const entries = await makeRequest({
+    method: 'GET',
+    url: '/entries?content_type=legacyWidget&limit=0',
+  })
+
+  if (entries.total > 0) {
+    throw new Error(
+      `Cannot delete legacyWidget: ${entries.total} entries still exist. ` +
+      'Delete or migrate them first.'
+    )
+  }
+
+  // Step 2: Remove reference fields pointing to this type from other content types
+  const page = migration.editContentType('page')
+  page.deleteField('legacyWidgetRef')
+
+  // Step 3: Delete the content type
+  migration.deleteContentType('legacyWidget')
+}
+
+export = migration
+```
+
+In practice, split this across multiple migrations:
+1. Migration 1: Remove reference fields and transform/migrate entries
+2. Migration 2: Delete the content type

--- a/skills/contentful/contentful-migration/references/running-migrations.md
+++ b/skills/contentful/contentful-migration/references/running-migrations.md
@@ -1,0 +1,193 @@
+# Running Migrations
+
+How to execute migration scripts using the CLI and programmatic API.
+
+## Prerequisites
+
+Install the `contentful-migration` package:
+
+```bash
+npm install contentful-migration
+```
+
+Requires Node.js 18 or later.
+
+You need a **Content Management API (CMA) access token** with write access to the target space. Generate one at: Settings > API keys > Content management tokens in the Contentful web app.
+
+## CLI Usage
+
+```bash
+npx contentful-migration --space-id <space-id> <migration-file>
+```
+
+### Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--space-id` | `-s` | Space ID (required) |
+| `--environment-id` | `-e` | Environment (default: `master`) |
+| `--access-token` | | CMA access token |
+| `--yes` | `-y` | Skip confirmation prompt |
+| `--retry-limit` | | Retries before failure (default: 5) |
+| `--config` | | Path to JSON config file |
+
+### Examples
+
+```bash
+# Run against master
+npx contentful-migration -s abc123 --access-token $CMA_TOKEN 001-create-blog.ts
+
+# Run against a sandbox environment
+npx contentful-migration -s abc123 -e sandbox --access-token $CMA_TOKEN 001-create-blog.ts
+
+# Skip confirmation
+npx contentful-migration -s abc123 -e sandbox --access-token $CMA_TOKEN -y 001-create-blog.ts
+
+# Run multiple migrations in order
+for f in migrations/*.ts; do
+  npx contentful-migration -s abc123 -e sandbox --access-token $CMA_TOKEN -y "$f"
+done
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `CONTENTFUL_MANAGEMENT_ACCESS_TOKEN` | CMA token (avoids passing `--access-token` every time) |
+
+```bash
+export CONTENTFUL_MANAGEMENT_ACCESS_TOKEN=CFPAT-xxxxx
+
+npx contentful-migration -s abc123 -e sandbox 001-create-blog.ts
+```
+
+## Programmatic API
+
+Use `runMigration()` to run migrations from Node.js scripts, test runners, or CI pipelines.
+
+```typescript
+import { runMigration } from 'contentful-migration'
+
+// From a file
+await runMigration({
+  filePath: './migrations/001-create-blog.ts',
+  spaceId: 'abc123',
+  accessToken: process.env.CONTENTFUL_MANAGEMENT_ACCESS_TOKEN!,
+  environmentId: 'sandbox',
+  yes: true,
+})
+
+// From a function
+await runMigration({
+  migrationFunction: (migration) => {
+    migration.createContentType('test', { name: 'Test' })
+  },
+  spaceId: 'abc123',
+  accessToken: process.env.CONTENTFUL_MANAGEMENT_ACCESS_TOKEN!,
+  environmentId: 'sandbox',
+  yes: true,
+})
+```
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `filePath` | string | — | Path to migration file (use this or `migrationFunction`) |
+| `migrationFunction` | function | — | Migration function directly |
+| `spaceId` | string | — | Space ID (required) |
+| `accessToken` | string | — | CMA token (required) |
+| `environmentId` | string | `'master'` | Target environment |
+| `yes` | boolean | `false` | Skip confirmation |
+| `retryLimit` | number | `5` | Retry attempts |
+| `requestBatchSize` | number | `100` | Batch size for API requests |
+| `headers` | object | — | Custom HTTP headers |
+| `host` | string | — | Custom API host |
+
+## Environment Strategy
+
+Never run untested migrations directly against your production environment.
+
+**Recommended workflow:**
+
+1. **Create a sandbox environment** from master (via the Contentful web app or CMA).
+
+2. **Run migrations against sandbox:**
+   ```bash
+   npx contentful-migration -s abc123 -e sandbox 001-create-blog.ts
+   ```
+
+3. **Verify** the content model and entries look correct in the web app.
+
+4. **Run against master** (or your production environment alias):
+   ```bash
+   npx contentful-migration -s abc123 -e master 001-create-blog.ts
+   ```
+
+5. **Delete the sandbox** when done (via the web app or CMA).
+
+For teams using **environment aliases**, point your production alias to the migrated environment rather than running migrations against the aliased environment directly.
+
+## Migration File Organization
+
+Name migration files with sequential prefixes so they run in order:
+
+```
+migrations/
+  001-create-author.ts
+  002-create-blog-post.ts
+  003-add-excerpt-to-blog-post.ts
+  004-transform-categories.ts
+  005-delete-legacy-widget.ts
+```
+
+Guidelines:
+- One logical change per file
+- Use descriptive names that explain what the migration does
+- Keep the numbering sequential with zero-padded prefixes
+- Commit migration files to version control
+- Never edit a migration that has already been applied — write a new one instead
+
+## Testing Migrations
+
+1. **Sandbox environments** are the primary testing mechanism. Create one, run the migration, verify, delete.
+
+2. **Dry-run approach:** Use `context.makeRequest` to read current state, log what would change, and return early:
+   ```typescript
+   import type { MigrationFunction } from 'contentful-migration'
+
+   const migration: MigrationFunction = async (migration, { makeRequest }) => {
+     const types = await makeRequest({ method: 'GET', url: '/content_types' })
+     console.log('Would affect:', types.items.map((t: any) => t.sys.id))
+     return
+   }
+
+   export = migration
+   ```
+
+3. **Programmatic tests:** Use `runMigration()` in your test suite against a dedicated test environment.
+
+## CI/CD Integration
+
+Run migrations as part of your deployment pipeline:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SPACE_ID="${CONTENTFUL_SPACE_ID}"
+ENV_ID="${DEPLOY_ENV:-master}"
+
+for migration in migrations/*.ts; do
+  echo "Running: $migration"
+  npx contentful-migration \
+    --space-id "$SPACE_ID" \
+    --environment-id "$ENV_ID" \
+    --yes \
+    "$migration"
+done
+```
+
+The `CONTENTFUL_MANAGEMENT_ACCESS_TOKEN` environment variable is picked up automatically.
+
+Track which migrations have been applied (e.g., in a version entry or external state file) to avoid re-running completed migrations.


### PR DESCRIPTION
## Summary

- Adds `contentful-migration` skill to help users write and run Contentful content model migration scripts using the `contentful-migration` package
- All examples use TypeScript with the `MigrationFunction` type from `contentful-migration`
- Includes comprehensive reference material split across three files for progressive disclosure:
  - `api-reference.md` — full API surface (content types, fields, validations, editor interface, layouts, sidebar, tags, annotations, taxonomy)
  - `patterns.md` — 14 copy-pasteable migration examples (CRUD, transforms, derive, editor layouts, etc.)
  - `running-migrations.md` — CLI via `npx contentful-migration`, programmatic API, environment strategy, CI/CD
- Updates README with new skill entry

## Test plan

- [ ] Run `python3 .agents/skills/skill-authoring/scripts/quick_validate.py skills/contentful/contentful-migration` — should pass
- [ ] Verify skill activates on trigger phrases like "write a migration", "create content type", "schema migration"
- [ ] Verify TypeScript examples compile against `contentful-migration` types
- [ ] Verify negative scope routing to `$contentful-nextjs` and `$contentful-guide` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)