### PR TITLE
docs(contentful): clarify env vars and contentful-cli migration usage

### DIFF
--- a/skills/contentful/contentful-migration/SKILL.md
+++ b/skills/contentful/contentful-migration/SKILL.md
@@ -2,7 +2,8 @@
 name: contentful-migration
 description: >-
   Write and run Contentful content model migration scripts using the
-  contentful-migration CLI and library. Covers creating, editing, and deleting
+  contentful-migration library and the Contentful CLI migration command. Covers
+  creating, editing, and deleting
   content types and fields, field types and validations, editor interface
   configuration, editor layouts, sidebar widgets, entry transformations, tags,
   annotations, and the migration context object. Use when asked to write a
@@ -37,7 +38,9 @@ This skill covers:
 - Entry transformations (in-place transforms, deriving linked entries, cross-type transforms)
 - Tags, annotations, taxonomy validations
 - Editor layouts, sidebar widgets
-- Running migrations via CLI and programmatic API
+- Running migrations via `npx contentful space migration` (Contentful CLI) and programmatic API
+
+Do not run migrations with `npx contentful-migration`. Use `contentful-cli` for CLI execution, install it as a dev dependency when needed, and run via `npx contentful ...`.
 
 Not covered: SDK client setup ($contentful-nextjs), Contentful concepts and API routing ($contentful-guide).
 

--- a/skills/contentful/contentful-migration/SKILL.md
+++ b/skills/contentful/contentful-migration/SKILL.md
@@ -70,11 +70,20 @@ The function also receives a `context` object as its second parameter, providing
 
 When writing a migration:
 
-1. **Assess the change.** Identify which content types and fields need to change. Check the current content model in the Contentful web app or via CMA.
-2. **Write the migration script.** Use the operations below. Prefer chaining over object notation — it gives better error messages with line numbers.
-3. **Test in a sandbox environment.** Never run untested migrations against production. Create a sandbox environment first: `contentful environment create --name sandbox --source master`.
-4. **Run the migration.** See [Running Migrations](references/running-migrations.md) for CLI and programmatic options.
-5. **Verify.** Check the content model in the web app. Confirm entries are intact.
+1. **Confirm required env vars first.** If values are missing, ask the user to add them to a local `.env` file before proceeding.
+2. **Assess the change.** Identify which content types and fields need to change. Check the current content model in the Contentful web app or via CMA.
+3. **Write the migration script.** Use the operations below. Prefer chaining over object notation — it gives better error messages with line numbers.
+4. **Test in a sandbox environment.** Never run untested migrations against production. Create a sandbox environment first: `contentful environment create --name sandbox --source master`.
+5. **Run the migration.** See [Running Migrations](references/running-migrations.md) for CLI and programmatic options.
+6. **Verify.** Check the content model in the web app. Confirm entries are intact.
+
+## Required environment variables
+
+- `CONTENTFUL_SPACE_ID` - Space ID. Find it in the Contentful web app URL (`/spaces/<SPACE_ID>/...`) or in **Space settings -> API keys**.
+- `CONTENTFUL_MANAGEMENT_ACCESS_TOKEN` - CMA token used for migrations. Create it in **Account settings -> CMA tokens** (`https://app.contentful.com/account/profile/cma_tokens`) or from a space-scoped CMA tokens page (`https://app.contentful.com/spaces/<SPACE_ID>/api/cma_tokens`).
+- `CONTENTFUL_ENVIRONMENT_ID` (optional) - Target environment ID (for example `master` or `sandbox`) when you want to avoid passing `--environment-id`.
+
+If any required value is missing, explicitly ask the user for the missing values and tell them where to find each one.
 
 ## Content Type Operations
 

--- a/skills/contentful/contentful-migration/references/running-migrations.md
+++ b/skills/contentful/contentful-migration/references/running-migrations.md
@@ -23,7 +23,7 @@ Create it in one of these places:
 ## CLI Usage (Contentful CLI)
 
 ```bash
-npx contentful space migration --space-id <space-id> <migration-file>
+npx contentful space migration --space-id <space-id> --management-token <cma-token> <migration-file>
 ```
 
 ### Flags

--- a/skills/contentful/contentful-migration/references/running-migrations.md
+++ b/skills/contentful/contentful-migration/references/running-migrations.md
@@ -1,16 +1,18 @@
 # Running Migrations
 
-How to execute migration scripts using the CLI and programmatic API.
+How to execute migration scripts using the Contentful CLI and programmatic API.
 
 ## Prerequisites
 
-Install the `contentful-migration` package:
+Install Contentful CLI as a dev dependency (if not already installed):
 
 ```bash
-npm install contentful-migration
+npm install --save-dev contentful-cli
 ```
 
 Requires Node.js 18 or later.
+
+Do not use `npx contentful-migration` as a CLI command. The migration CLI command is in `contentful-cli`, and should be run via `npx contentful ...`.
 
 You need a **Content Management API (CMA) access token** with write access to the target space.
 
@@ -18,10 +20,10 @@ Create it in one of these places:
 - Account settings -> CMA tokens: `https://app.contentful.com/account/profile/cma_tokens`
 - Space-scoped CMA tokens page: `https://app.contentful.com/spaces/<SPACE_ID>/api/cma_tokens`
 
-## CLI Usage
+## CLI Usage (Contentful CLI)
 
 ```bash
-npx contentful-migration --space-id <space-id> <migration-file>
+npx contentful space migration --space-id <space-id> <migration-file>
 ```
 
 ### Flags
@@ -30,7 +32,7 @@ npx contentful-migration --space-id <space-id> <migration-file>
 |------|-------|-------------|
 | `--space-id` | `-s` | Space ID (required) |
 | `--environment-id` | `-e` | Environment (default: `master`) |
-| `--access-token` | | CMA access token |
+| `--management-token` | `--mt` | CMA access token |
 | `--yes` | `-y` | Skip confirmation prompt |
 | `--retry-limit` | | Retries before failure (default: 5) |
 | `--config` | | Path to JSON config file |
@@ -39,17 +41,17 @@ npx contentful-migration --space-id <space-id> <migration-file>
 
 ```bash
 # Run against master
-npx contentful-migration -s abc123 --access-token $CMA_TOKEN 001-create-blog.ts
+npx contentful space migration -s abc123 --management-token "$CMA_TOKEN" 001-create-blog.ts
 
 # Run against a sandbox environment
-npx contentful-migration -s abc123 -e sandbox --access-token $CMA_TOKEN 001-create-blog.ts
+npx contentful space migration -s abc123 -e sandbox --management-token "$CMA_TOKEN" 001-create-blog.ts
 
 # Skip confirmation
-npx contentful-migration -s abc123 -e sandbox --access-token $CMA_TOKEN -y 001-create-blog.ts
+npx contentful space migration -s abc123 -e sandbox --management-token "$CMA_TOKEN" -y 001-create-blog.ts
 
 # Run multiple migrations in order
 for f in migrations/*.ts; do
-  npx contentful-migration -s abc123 -e sandbox --access-token $CMA_TOKEN -y "$f"
+  npx contentful space migration -s abc123 -e sandbox --management-token "$CMA_TOKEN" -y "$f"
 done
 ```
 
@@ -58,7 +60,7 @@ done
 | Variable | Description |
 |----------|-------------|
 | `CONTENTFUL_SPACE_ID` | Space ID used by CLI examples and scripts |
-| `CONTENTFUL_MANAGEMENT_ACCESS_TOKEN` | CMA token (avoids passing `--access-token` every time) |
+| `CONTENTFUL_MANAGEMENT_ACCESS_TOKEN` | CMA token used to set `--management-token` |
 | `CONTENTFUL_ENVIRONMENT_ID` | Optional default environment ID (for example `master` or `sandbox`) |
 
 ```bash
@@ -76,12 +78,19 @@ Where to find each value:
 If any required value is missing, ask the user to populate it in `.env` before running migrations.
 
 ```bash
-npx contentful-migration -s abc123 -e sandbox 001-create-blog.ts
+CMA_TOKEN="${CONTENTFUL_MANAGEMENT_ACCESS_TOKEN}"
+npx contentful space migration -s abc123 -e sandbox --management-token "$CMA_TOKEN" 001-create-blog.ts
 ```
 
 ## Programmatic API
 
 Use `runMigration()` to run migrations from Node.js scripts, test runners, or CI pipelines.
+
+Install the library for programmatic usage:
+
+```bash
+npm install contentful-migration
+```
 
 ```typescript
 import { runMigration } from 'contentful-migration'
@@ -132,14 +141,14 @@ Never run untested migrations directly against your production environment.
 
 2. **Run migrations against sandbox:**
    ```bash
-   npx contentful-migration -s abc123 -e sandbox 001-create-blog.ts
+   npx contentful space migration -s abc123 -e sandbox --management-token "$CMA_TOKEN" 001-create-blog.ts
    ```
 
 3. **Verify** the content model and entries look correct in the web app.
 
 4. **Run against master** (or your production environment alias):
    ```bash
-   npx contentful-migration -s abc123 -e master 001-create-blog.ts
+   npx contentful space migration -s abc123 -e master --management-token "$CMA_TOKEN" 001-create-blog.ts
    ```
 
 5. **Delete the sandbox** when done (via the web app or CMA).
@@ -198,14 +207,15 @@ ENV_ID="${DEPLOY_ENV:-master}"
 
 for migration in migrations/*.ts; do
   echo "Running: $migration"
-  npx contentful-migration \
+  npx contentful space migration \
     --space-id "$SPACE_ID" \
     --environment-id "$ENV_ID" \
+    --management-token "$CONTENTFUL_MANAGEMENT_ACCESS_TOKEN" \
     --yes \
     "$migration"
 done
 ```
 
-The `CONTENTFUL_MANAGEMENT_ACCESS_TOKEN` environment variable is picked up automatically.
+This script reads `CONTENTFUL_MANAGEMENT_ACCESS_TOKEN` from your shell environment and passes it to `--management-token`.
 
 Track which migrations have been applied (e.g., in a version entry or external state file) to avoid re-running completed migrations.

--- a/skills/contentful/contentful-migration/references/running-migrations.md
+++ b/skills/contentful/contentful-migration/references/running-migrations.md
@@ -12,7 +12,11 @@ npm install contentful-migration
 
 Requires Node.js 18 or later.
 
-You need a **Content Management API (CMA) access token** with write access to the target space. Generate one at: Settings > API keys > Content management tokens in the Contentful web app.
+You need a **Content Management API (CMA) access token** with write access to the target space.
+
+Create it in one of these places:
+- Account settings -> CMA tokens: `https://app.contentful.com/account/profile/cma_tokens`
+- Space-scoped CMA tokens page: `https://app.contentful.com/spaces/<SPACE_ID>/api/cma_tokens`
 
 ## CLI Usage
 
@@ -53,11 +57,25 @@ done
 
 | Variable | Description |
 |----------|-------------|
+| `CONTENTFUL_SPACE_ID` | Space ID used by CLI examples and scripts |
 | `CONTENTFUL_MANAGEMENT_ACCESS_TOKEN` | CMA token (avoids passing `--access-token` every time) |
+| `CONTENTFUL_ENVIRONMENT_ID` | Optional default environment ID (for example `master` or `sandbox`) |
 
 ```bash
-export CONTENTFUL_MANAGEMENT_ACCESS_TOKEN=CFPAT-xxxxx
+# .env
+CONTENTFUL_SPACE_ID=your_space_id
+CONTENTFUL_MANAGEMENT_ACCESS_TOKEN=your_cma_token
+CONTENTFUL_ENVIRONMENT_ID=sandbox
+```
 
+Where to find each value:
+- `CONTENTFUL_SPACE_ID`: in the Contentful URL (`/spaces/<SPACE_ID>/...`) or **Space settings -> API keys**.
+- `CONTENTFUL_MANAGEMENT_ACCESS_TOKEN`: **Account settings -> CMA tokens** (`https://app.contentful.com/account/profile/cma_tokens`) or `https://app.contentful.com/spaces/<SPACE_ID>/api/cma_tokens`.
+- `CONTENTFUL_ENVIRONMENT_ID`: **Space settings -> Environments** (for example `master`, `sandbox`, `staging`).
+
+If any required value is missing, ask the user to populate it in `.env` before running migrations.
+
+```bash
 npx contentful-migration -s abc123 -e sandbox 001-create-blog.ts
 ```
 

--- a/skills/contentful/contentful-nextjs/SKILL.md
+++ b/skills/contentful/contentful-nextjs/SKILL.md
@@ -35,7 +35,7 @@ Contentful is a headless, API-first CMS (composable content platform) that lets 
 
 1. Check the latest stable Next.js release online at `https://github.com/vercel/next.js/releases` when version-specific guidance is needed.
 2. Confirm Next.js project structure (App Router vs Pages Router).
-3. Configure required env vars.
+3. Configure required env vars. If they are missing, ask the user to add them to `.env.local` before continuing, and explain where to find each value.
 4. Install and initialize `contentful` SDK.
 5. Implement published-content fetching.
 6. Add preview-aware behavior for Draft Mode.
@@ -49,9 +49,13 @@ Contentful is a headless, API-first CMS (composable content platform) that lets 
 
 ## Required environment variables
 
-- `CONTENTFUL_SPACE_ID`
-- `CONTENTFUL_ACCESS_TOKEN`
-- `CONTENTFUL_PREVIEW_ACCESS_TOKEN` (for preview workflows)
+- `CONTENTFUL_SPACE_ID` - Find it in the Contentful URL (`/spaces/<SPACE_ID>/...`) or in **Space settings -> API keys**.
+- `CONTENTFUL_ACCESS_TOKEN` - CDA token from **Space settings -> API keys**.
+- `CONTENTFUL_PREVIEW_ACCESS_TOKEN` (for preview workflows) - CPA token from **Space settings -> API keys**.
+
+Creating an API key in Contentful provides both tokens needed here:
+- CDA token -> `CONTENTFUL_ACCESS_TOKEN`
+- CPA token -> `CONTENTFUL_PREVIEW_ACCESS_TOKEN`
 
 ## Defaults
 

--- a/skills/contentful/contentful-nextjs/references/nextjs-setup.md
+++ b/skills/contentful/contentful-nextjs/references/nextjs-setup.md
@@ -30,7 +30,17 @@ CONTENTFUL_ENVIRONMENT_ALIAS=master
 CONTENTFUL_ENVIRONMENT_ID=master
 ```
 
-Get values in Contentful at **Settings -> API keys**.
+If these values are missing, ask the user to add them to `.env.local` before continuing.
+
+Where to find each value:
+- `CONTENTFUL_SPACE_ID`: in the Contentful URL (`/spaces/<SPACE_ID>/...`) or **Space settings -> API keys**.
+- `CONTENTFUL_ACCESS_TOKEN`: from **Space settings -> API keys** (CDA token).
+- `CONTENTFUL_PREVIEW_ACCESS_TOKEN`: from **Space settings -> API keys** (CPA token / Content Preview API).
+- `CONTENTFUL_ENVIRONMENT_ALIAS` and `CONTENTFUL_ENVIRONMENT_ID`: **Space settings -> Environments** / environment aliases.
+
+Creating a single API key in Contentful gives both content delivery tokens:
+- CDA token -> `CONTENTFUL_ACCESS_TOKEN`
+- CPA token -> `CONTENTFUL_PREVIEW_ACCESS_TOKEN`
 
 ## 3) Create a shared client factory
 


### PR DESCRIPTION
## Summary
- add explicit missing-env guidance for Contentful migration and Next.js setup flows, including where users can find each required variable
- clarify that CMA tokens come from account/space CMA token pages and that API keys provide both CDA and CPA tokens
- switch migration CLI docs from `npx contentful-migration` to `contentful-cli` usage via `npx contentful space migration`, with `contentful-cli` installed as a dev dependency

## Commits
- docs(contentful): add env var setup guidance for migration and Next.js
- docs(contentful-migration): switch CLI usage to contentful-cli via npx