### PR TITLE
docs(optimization): gate setup on readiness and soften baseline messaging

### DIFF
--- a/skills/contentful/contentful-guide/references/lexicon.md
+++ b/skills/contentful/contentful-guide/references/lexicon.md
@@ -25,7 +25,6 @@ Contentful is a headless, API-first CMS (composable content platform) that separ
 
 ## Common shorthand
 
-- **a13y**: Accessibility.
 - **p13n**: Personalization.
 - **cf** or **ctfl**: Contentful.
 

--- a/skills/contentful/contentful-guide/references/lexicon.md
+++ b/skills/contentful/contentful-guide/references/lexicon.md
@@ -23,6 +23,12 @@ Contentful is a headless, API-first CMS (composable content platform) that separ
 - **GraphQL Content API**: GraphQL endpoint generated from content model.
 - **Images API**: Image transformation and optimization endpoints.
 
+## Common shorthand
+
+- **a13y**: Accessibility.
+- **p13n**: Personalization.
+- **cf** or **ctfl**: Contentful.
+
 ## Alias usage notes
 
 - Use an alias when you want stable API paths across deploys while switching the target environment.

--- a/skills/contentful/contentful-guide/references/lexicon.md
+++ b/skills/contentful/contentful-guide/references/lexicon.md
@@ -26,6 +26,7 @@ Contentful is a headless, API-first CMS (composable content platform) that separ
 ## Common shorthand
 
 - **p13n**: Personalization.
+- **ninetailed**: Personalization.
 - **cf** or **ctfl**: Contentful.
 
 ## Alias usage notes

--- a/skills/optimization/optimization-readiness/SKILL.md
+++ b/skills/optimization/optimization-readiness/SKILL.md
@@ -54,11 +54,15 @@ assess readiness. Then produce the final report.
 5. If none of the above: plain React (CRA, Vite, custom)
 
 **Assess**:
-- Next.js (any version) → Fully supported
+- Next.js 13.4+ → Fully supported (App Router stable)
+- Next.js 12.x to 13.3 → Supported with caution (prefer Pages Router patterns)
+- Next.js < 12 (for example Next.js 10/11) → `NOT READY` for setup; recommend framework upgrade first
 - Gatsby → Supported (client-side only)
 - Remix → Partially supported (community patterns)
 - Plain React → Supported (client-side only)
 - Non-React framework → Not currently supported
+
+If the framework baseline is below supported levels, explicitly block setup work and route the user to prerequisite upgrades before running $optimization-setup.
 
 ### B. Contentful SDK Setup
 
@@ -107,9 +111,14 @@ assess readiness. Then produce the final report.
    - `NinetailedPrivacyPlugin` → consent management
 
 **Assess**:
-- No packages installed → Fresh setup (use $optimization-setup)
-- Packages installed but no provider → Partially configured, needs completion
-- Provider configured with plugins → Already set up (check completeness)
+- No packages installed → `NOT INSTALLED` (expected baseline for first-time adoption; use $optimization-setup)
+- Packages installed but no provider → `PARTIAL SETUP` (installation started, wiring still needed)
+- Provider configured with plugins → `CONFIGURED` (check completeness and plugin fit)
+
+Important tone guidance for this section:
+- Treat "no Ninetailed packages" as neutral, not a failure.
+- Do **not** label check C as `NOT READY` when a project simply has no existing personalization SDK.
+- Prefer wording like "Fresh setup" or "Not installed yet".
 
 ### D. Component Architecture
 
@@ -220,7 +229,7 @@ After completing all checks, produce a report in this format:
 - [Environment variables status]
 - [Include depth assessment]
 
-### Existing Ninetailed Setup: [STATUS]
+### Existing Ninetailed Setup: [NOT INSTALLED / PARTIAL SETUP / CONFIGURED]
 - [Packages found / not found]
 - [Provider status]
 - [Plugin status]
@@ -246,11 +255,16 @@ After completing all checks, produce a report in this format:
 Use $optimization-setup for guided installation and configuration.
 ```
 
-**Status markers**: Use these consistently:
+**Status markers**: Use these consistently for framework/contentful/component/rendering checks:
 - `READY` — No changes needed for this area
 - `MINOR CHANGES` — Small fixes (config tweaks, increasing include depth)
 - `NEEDS WORK` — Moderate effort (add mapper, restructure fetching)
 - `NOT READY` — Significant restructuring required
+
+For **Existing Ninetailed Setup** only (check C), use:
+- `NOT INSTALLED` — Neutral baseline; setup not started yet
+- `PARTIAL SETUP` — Installation started but incomplete
+- `CONFIGURED` — Provider and core wiring present
 
 ## Example Report
 

--- a/skills/optimization/optimization-readiness/SKILL.md
+++ b/skills/optimization/optimization-readiness/SKILL.md
@@ -55,8 +55,8 @@ assess readiness. Then produce the final report.
 
 **Assess**:
 - Next.js 13.4+ → Fully supported (App Router stable)
-- Next.js 12.x to 13.3 → Supported with caution (prefer Pages Router patterns)
-- Next.js < 12 (for example Next.js 10/11) → `NOT READY` for setup; recommend framework upgrade first
+- Next.js 13.0 to 13.3 → Supported with caution (App Router is experimental; prefer Pages Router patterns)
+- Next.js < 13 (for example Next.js 10/11/12) → `NOT READY` for setup; recommend framework upgrade first
 - Gatsby → Supported (client-side only)
 - Remix → Partially supported (community patterns)
 - Plain React → Supported (client-side only)

--- a/skills/optimization/optimization-readiness/references/how-personalization-works.md
+++ b/skills/optimization/optimization-readiness/references/how-personalization-works.md
@@ -6,7 +6,6 @@ present or missing.
 
 ## Common shorthand
 
-- **a13y** means accessibility.
 - **p13n** or **ninetailed** means personalization.
 - **cf** or **ctfl** means Contentful.
 

--- a/skills/optimization/optimization-readiness/references/how-personalization-works.md
+++ b/skills/optimization/optimization-readiness/references/how-personalization-works.md
@@ -4,6 +4,12 @@ Use this reference to explain your readiness findings to the user. When
 reporting what you found, explain **why** it matters — not just what's
 present or missing.
 
+## Common shorthand
+
+- **a13y** means accessibility.
+- **p13n** or **ninetailed** means personalization.
+- **cf** or **ctfl** means Contentful.
+
 ## The Core Idea
 
 Contentful Personalization (powered by Ninetailed) lets content authors

--- a/skills/optimization/optimization-readiness/references/readiness-criteria.md
+++ b/skills/optimization/optimization-readiness/references/readiness-criteria.md
@@ -6,9 +6,9 @@ Detailed rubric for each readiness check.
 
 | Framework | Version | Support Level | Notes |
 |-----------|---------|--------------|-------|
-| Next.js (Pages Router) | 12+ | Full | SSR, SSG, ISR all supported |
+| Next.js (Pages Router) | 13+ | Full | SSR, SSG, ISR all supported |
 | Next.js (App Router) | 13.4+ | Full | Server Components require client boundary for provider |
-| Next.js (older baseline) | < 12 | Not ready for setup | Upgrade Next.js before starting personalization setup |
+| Next.js (older baseline) | < 13 | Not ready for setup | Upgrade Next.js before starting personalization setup |
 | Gatsby | 4+ | Full (client-side) | No SSR personalization; plugin-based provider |
 | Remix | 1+ | Partial | Community patterns; loader-based data fetching compatible |
 | React (CRA) | 16.8+ | Full (client-side) | Hooks required; no SSR |
@@ -18,9 +18,8 @@ Detailed rubric for each readiness check.
 
 ### Next.js Version Details
 
-- **< 12.0**: Too old for this setup workflow. Mark as `NOT READY` and require upgrade.
-- **12.x**: Pages Router baseline supported.
-- **13.0-13.3**: App Router experimental. Prefer Pages Router patterns.
+- **< 13.0**: Too old for this setup workflow. Mark as `NOT READY` and require upgrade.
+- **13.0-13.3**: Pages Router baseline supported; App Router is experimental.
 - **13.4+**: App Router stable. Both routers supported.
 - **14+**: App Router preferred. Server Actions available but not required.
 
@@ -139,7 +138,7 @@ The overall verdict is the **worst** individual assessment, with one exception:
 
 Hard gate:
 
-- If framework compatibility is below baseline (for example Next.js < 12), the
+- If framework compatibility is below baseline (for example Next.js < 13), the
   overall should be treated as blocked for setup until upgrade prerequisites are complete.
 
 | Worst Individual | Overall |

--- a/skills/optimization/optimization-readiness/references/readiness-criteria.md
+++ b/skills/optimization/optimization-readiness/references/readiness-criteria.md
@@ -6,8 +6,9 @@ Detailed rubric for each readiness check.
 
 | Framework | Version | Support Level | Notes |
 |-----------|---------|--------------|-------|
-| Next.js (Pages Router) | Any | Full | SSR, SSG, ISR all supported |
+| Next.js (Pages Router) | 12+ | Full | SSR, SSG, ISR all supported |
 | Next.js (App Router) | 13.4+ | Full | Server Components require client boundary for provider |
+| Next.js (older baseline) | < 12 | Not ready for setup | Upgrade Next.js before starting personalization setup |
 | Gatsby | 4+ | Full (client-side) | No SSR personalization; plugin-based provider |
 | Remix | 1+ | Partial | Community patterns; loader-based data fetching compatible |
 | React (CRA) | 16.8+ | Full (client-side) | Hooks required; no SSR |
@@ -17,8 +18,9 @@ Detailed rubric for each readiness check.
 
 ### Next.js Version Details
 
-- **< 13.0**: Pages Router only. Fully supported.
-- **13.0-13.3**: App Router experimental. Pages Router recommended.
+- **< 12.0**: Too old for this setup workflow. Mark as `NOT READY` and require upgrade.
+- **12.x**: Pages Router baseline supported.
+- **13.0-13.3**: App Router experimental. Prefer Pages Router patterns.
 - **13.4+**: App Router stable. Both routers supported.
 - **14+**: App Router preferred. Server Actions available but not required.
 
@@ -42,6 +44,20 @@ Detailed rubric for each readiness check.
 | Env vars | Space ID + token in .env | Hardcoded values | Neither .env nor hardcoded |
 | Include depth | ≥ 3 in queries | 2 (works with `.withoutUnresolvableLinks`) | < 2 (easy fix — increase value) |
 | Preview client | Configured | — | Not configured (optional) |
+
+## Existing Ninetailed Setup Rubric
+
+This check measures adoption progress, not code quality.
+
+| Situation | Status | Guidance |
+|----------|--------|----------|
+| No `@ninetailed/experience.js*` packages found | `NOT INSTALLED` | Neutral baseline for projects that have not started personalization yet |
+| Packages found but provider/wrappers missing | `PARTIAL SETUP` | Installation started; wiring and usage still needed |
+| Provider + core wrappers/plugins found | `CONFIGURED` | Existing setup present; validate completeness |
+
+Tone guidance:
+- Do not call this state `NOT READY` when the SDK is simply not installed yet.
+- Prefer neutral wording: "fresh setup", "not installed yet", or "setup not started".
 
 ## Component Architecture Rubric
 
@@ -120,6 +136,11 @@ The overall verdict is the **worst** individual assessment, with one exception:
 - If the only issue is "no Ninetailed packages installed" (check C) but all
   other checks pass, the overall is still **READY** — installing packages is
   what $optimization-setup handles.
+
+Hard gate:
+
+- If framework compatibility is below baseline (for example Next.js < 12), the
+  overall should be treated as blocked for setup until upgrade prerequisites are complete.
 
 | Worst Individual | Overall |
 |-----------------|---------|

--- a/skills/optimization/optimization-setup/SKILL.md
+++ b/skills/optimization/optimization-setup/SKILL.md
@@ -45,7 +45,11 @@ Follow these steps in order. Do not skip the Contentful app setup or verificatio
 1. Run $optimization-readiness to understand framework, router, rendering mode, and component mapping patterns.
 2. Confirm the project already fetches Contentful content successfully.
 3. Confirm whether personalization must happen in the browser only, on the server, at the edge, or in a hybrid setup.
-4. If readiness gaps are found, fix those before wiring the SDK.
+4. Treat readiness as a hard gate before setup implementation:
+   - If readiness is `NEEDS WORK` or `SIGNIFICANT RESTRUCTURING NEEDED`, stop setup and give a prerequisite-fix plan first.
+   - If the framework/runtime is below supported baseline (for example Next.js 10), do not install SDK packages yet.
+   - Resume setup only after prerequisites are fixed and readiness is re-run.
+5. If readiness gaps are found, fix those before wiring the SDK.
 
 ### 2) Complete the Contentful Setup Before Writing App Code
 
@@ -227,3 +231,8 @@ When applying this skill, return:
 - verification results and remaining risks
 
 If the agent cannot complete Contentful UI steps directly, it must still leave the user with an exact checklist of what to click and configure.
+
+Always include a readiness gate statement:
+
+- `Readiness passed, proceeding with setup.`
+- or `Readiness not passed, prerequisite upgrades required before setup.`

--- a/skills/optimization/optimization-setup/SKILL.md
+++ b/skills/optimization/optimization-setup/SKILL.md
@@ -47,7 +47,7 @@ Follow these steps in order. Do not skip the Contentful app setup or verificatio
 3. Confirm whether personalization must happen in the browser only, on the server, at the edge, or in a hybrid setup.
 4. Treat readiness as a hard gate before setup implementation:
    - If readiness is `NEEDS WORK` or `SIGNIFICANT RESTRUCTURING NEEDED`, stop setup and give a prerequisite-fix plan first.
-   - If the framework/runtime is below supported baseline (for example Next.js 10), do not install SDK packages yet.
+   - If the framework/runtime is below supported baseline (for example Next.js 12), do not install SDK packages yet.
    - Resume setup only after prerequisites are fixed and readiness is re-run.
 5. If readiness gaps are found, fix those before wiring the SDK.
 


### PR DESCRIPTION
## Summary
- soften optimization readiness wording so missing Ninetailed packages are reported as a neutral adoption state (`NOT INSTALLED`) instead of a failure
- enforce readiness as a hard gate before setup work in `optimization-setup`, including explicit prerequisite guidance when setup is blocked
- raise the Next.js setup/readiness baseline to 13+ (with 13.0-13.3 cautions and 13.4+ App Router stable guidance)
- normalize shorthand terminology to `p13n` and `cf`/`ctfl` in the relevant references

## Testing
- docs-only changes; no runtime tests required