### PR TITLE
docs(skills): replace shorthand skill refs with explicit skill names

### DIFF
--- a/skills/contentful/contentful-guide/SKILL.md
+++ b/skills/contentful/contentful-guide/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   or ask where to find the correct docs for a task. Also triggers on "Contentful
   101", "which Contentful API should I use", "how do I get started", and
   "which skill should I use". Not for framework-specific implementation steps;
-  route those to $contentful-nextjs or other specialized skills.
+  route those to the contentful-nextjs skill or other specialized skills.
 ---
 
 # Contentful Guide
@@ -25,7 +25,7 @@ Contentful is a headless, API-first CMS (composable content platform) where team
 
 ## Routing rules
 
-- If the user asks to add Contentful to a Next.js project, use $contentful-nextjs.
+- If the user asks to add Contentful to a Next.js project, use the contentful-nextjs skill.
 - If the user asks about optimization/personalization/analytics setup or debugging, route to optimization skills.
 - If the user asks for conceptual guidance, architecture tradeoffs, or where to read docs, stay in this skill.
 - If the user asks about environment aliases and deployment workflows, stay in this skill unless they also ask for framework implementation.

--- a/skills/contentful/contentful-guide/references/skill-routing.md
+++ b/skills/contentful/contentful-guide/references/skill-routing.md
@@ -12,7 +12,7 @@ Stay here when the user asks:
 - "What is the difference between space/environment/content type?"
 - "How do environment aliases work?"
 
-## Route to `$contentful-nextjs`
+## Route to `the contentful-nextjs skill`
 
 Route when the user asks to:
 

--- a/skills/contentful/contentful-migration/SKILL.md
+++ b/skills/contentful/contentful-migration/SKILL.md
@@ -13,8 +13,8 @@ description: >-
   "space migration", "content model migration", "field validation", "editor
   interface", "field control", "moveField", "changeFieldId", "write a migration",
   "create content type", "add field to content type". Not for SDK client setup
-  or Next.js integration — use $contentful-nextjs. Not for Contentful terminology
-  or API routing — use $contentful-guide.
+  or Next.js integration — use the contentful-nextjs skill. Not for Contentful terminology
+  or API routing — use the contentful-guide skill.
 license: MIT
 ---
 
@@ -42,7 +42,7 @@ This skill covers:
 
 Do not run migrations with `npx contentful-migration`. Use `contentful-cli` for CLI execution, install it as a dev dependency when needed, and run via `npx contentful ...`.
 
-Not covered: SDK client setup ($contentful-nextjs), Contentful concepts and API routing ($contentful-guide).
+Not covered: SDK client setup (the contentful-nextjs skill), Contentful concepts and API routing (the contentful-guide skill).
 
 ## Migration Script Format
 
@@ -286,5 +286,5 @@ See [API Reference — Editor Interface](references/api-reference.md#editor-inte
 
 ## Related Skills
 
-- $contentful-guide — Contentful concepts, terminology, API routing
-- $contentful-nextjs — Next.js integration with Contentful
+- the contentful-guide skill — Contentful concepts, terminology, API routing
+- the contentful-nextjs skill — Next.js integration with Contentful

--- a/skills/optimization/optimization-readiness/SKILL.md
+++ b/skills/optimization/optimization-readiness/SKILL.md
@@ -10,8 +10,8 @@ description: >-
   for personalization", "can I install Ninetailed", "is my project ready", "evaluate
   my codebase", "readiness check", "can my app support A/B testing", "pre-check",
   "prerequisites for personalization". Not for installing or configuring SDKs — use
-  $optimization-setup for that. Not for diagnosing issues in an existing setup — use
-  $optimization-doctor for that.
+  the optimization-setup skill for that. Not for diagnosing issues in an existing setup — use
+  the optimization-doctor skill for that.
 license: MIT
 ---
 
@@ -62,7 +62,7 @@ assess readiness. Then produce the final report.
 - Plain React → Supported (client-side only)
 - Non-React framework → Not currently supported
 
-If the framework baseline is below supported levels, explicitly block setup work and route the user to prerequisite upgrades before running $optimization-setup.
+If the framework baseline is below supported levels, explicitly block setup work and route the user to prerequisite upgrades before running the optimization-setup skill.
 
 ### B. Contentful SDK Setup
 
@@ -111,7 +111,7 @@ If the framework baseline is below supported levels, explicitly block setup work
    - `NinetailedPrivacyPlugin` → consent management
 
 **Assess**:
-- No packages installed → `NOT INSTALLED` (expected baseline for first-time adoption; use $optimization-setup)
+- No packages installed → `NOT INSTALLED` (expected baseline for first-time adoption; use the optimization-setup skill)
 - Packages installed but no provider → `PARTIAL SETUP` (installation started, wiring still needed)
 - Provider configured with plugins → `CONFIGURED` (check completeness and plugin fit)
 
@@ -252,7 +252,7 @@ After completing all checks, produce a report in this format:
 2. [...]
 3. [...]
 
-Use $optimization-setup for guided installation and configuration.
+Use the optimization-setup skill for guided installation and configuration.
 ```
 
 **Status markers**: Use these consistently for framework/contentful/component/rendering checks:
@@ -287,7 +287,7 @@ For **Existing Ninetailed Setup** only (check C), use:
 ### Existing Ninetailed Setup: NOT INSTALLED
 - No `@ninetailed/*` packages in package.json
 - No NinetailedProvider in source
-- Fresh setup — use $optimization-setup for guided installation
+- Fresh setup — use the optimization-setup skill for guided installation
 
 ### Component Architecture: MINOR CHANGES
 - Component mapper found in `components/Renderer/BlockRenderer.tsx`
@@ -307,7 +307,7 @@ For **Existing Ninetailed Setup** only (check C), use:
 
 ### Recommendations
 1. Add `callout` and `stat-grid` to the ContentTypeMap in BlockRenderer.tsx
-2. Run $optimization-setup for guided Ninetailed SDK installation
+2. Run the optimization-setup skill for guided Ninetailed SDK installation
 3. Edge middleware detected — consider server-side personalization for no-flash experience
 ```
 
@@ -324,4 +324,4 @@ The **overall assessment** is determined by the worst-performing area:
 
 Exception: if the only issue is "no Ninetailed packages installed" but
 everything else is ready, the overall assessment is still **READY** — that's
-what $optimization-setup is for.
+what the optimization-setup skill is for.

--- a/skills/optimization/optimization-readiness/references/readiness-criteria.md
+++ b/skills/optimization/optimization-readiness/references/readiness-criteria.md
@@ -103,7 +103,7 @@ Report any gaps:
 
 ## Environment Variables Checklist
 
-### Required for Ninetailed (will be needed by $optimization-setup)
+### Required for Ninetailed (will be needed by the optimization-setup skill)
 
 ```
 NEXT_PUBLIC_NINETAILED_CLIENT_ID    # Ninetailed API key
@@ -134,7 +134,7 @@ The overall verdict is the **worst** individual assessment, with one exception:
 
 - If the only issue is "no Ninetailed packages installed" (check C) but all
   other checks pass, the overall is still **READY** — installing packages is
-  what $optimization-setup handles.
+  what the optimization-setup skill handles.
 
 Hard gate:
 

--- a/skills/optimization/optimization-setup/SKILL.md
+++ b/skills/optimization/optimization-setup/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: optimization-setup
 description: >-
-  Set up Contentful Personalization end to end in Contentful and code. Covers
+  Set up Contentful Personalization end-to-end in Contentful and code. Covers
   Contentful app installation, data buckets, nt_experience/nt_audience/nt_mergetag
   content model setup, the current production `@ninetailed/experience.js` SDKs,
   the modern `@contentful/optimization` SDKs, Next.js Pages Router and App Router,
   SSR and edge preflight, cookie handling, analytics, preview, and verification.
   Use when asked to set up personalization, install Contentful Personalization,
-  configure Ninetailed, wire the new optimization SDKs, or prepare A/B testing.
-  Not for readiness audits or debugging broken integrations; use
-  $optimization-readiness or $optimization-doctor.
+  configure Ninetailed, wire the new optimization SDKs, prepare A/B testing or just 
+  about how to personalize. Not for readiness audits or debugging broken integrations; use
+  the optimization-readiness skill or the optimization-doctor skill.
 ---
 
 # Optimization Setup
 
-Use this skill to implement a complete customer-ready personalization setup.
+Use this skill to implement a complete customer-ready personalization setup. Always start with the optimization-readiness skill first to assess the project.
 
 ## Default Recommendation
 
@@ -33,16 +33,16 @@ Use this skill to implement a complete customer-ready personalization setup.
 - Next.js Pages Router or App Router integration work
 - Contentful Personalization app installation and content-model preparation
 - Analytics, preview, or middleware setup as part of initial implementation
-- NOT for readiness assessment, use $optimization-readiness
-- NOT for debugging a broken setup, use $optimization-doctor
+- NOT for readiness assessment, use the optimization-readiness skill
+- NOT for debugging a broken setup, use the optimization-doctor skill
 
 ## Setup Workflow
 
 Follow these steps in order. Do not skip the Contentful app setup or verification steps.
 
-### 1) Run a Readiness Check First
+### 1) Run an Optimization Readiness Check First
 
-1. Run $optimization-readiness to understand framework, router, rendering mode, and component mapping patterns.
+1. Run the optimization-readiness skill to understand framework, router, rendering mode, and component mapping patterns.
 2. Confirm the project already fetches Contentful content successfully.
 3. Confirm whether personalization must happen in the browser only, on the server, at the edge, or in a hybrid setup.
 4. Treat readiness as a hard gate before setup implementation:
@@ -201,7 +201,7 @@ For details, see [references/analytics-and-preview.md](references/analytics-and-
 6. Confirm click or component insights fire when expected.
 7. Confirm preview only appears where intended.
 8. Confirm SSR or edge flows keep the anonymous ID stable across requests.
-9. If verification fails, move to $optimization-doctor.
+9. If verification fails, move to the optimization-doctor skill.
 
 ## Common Failure Modes
 


### PR DESCRIPTION
## Summary
- Replace `$skill-name` cross-skill references with explicit phrasing like "the <skill-name> skill".
- Update Contentful and Optimization skill docs for consistent routing language.
- Keep commit scope to distributed `skills/` content; exclude disabled `skill-authoring` edits.