### PR TITLE
docs(contentful): add Contentful MCP guidance notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Works with Claude Code, Cursor, GitHub Copilot, OpenAI Codex, Gemini CLI, and [3
 npx skills add contentful/skills
 ```
 
+## Contentful MCP Server
+
+If you want to interact with Contentful more easily through AI agents, use the Contentful MCP server:
+
+- Docs: `https://www.contentful.com/developers/docs/tools/mcp-server/`
+- It provides a simpler conversational interface to work with Contentful content and models.
+
 ## Available Skills
 
 ### Contentful

--- a/skills/contentful/contentful-guide/SKILL.md
+++ b/skills/contentful/contentful-guide/SKILL.md
@@ -4,6 +4,8 @@ description: >-
   Explain core Contentful concepts and route users to the right implementation skill
   or documentation. Use when users ask "what is" questions, need Contentful
   terminology clarified, need help choosing between APIs (CDA/CMA/CPA/GraphQL),
+  ask about the Contentful MCP server, or want easier agent-driven interaction with
+  Contentful,
   or ask where to find the correct docs for a task. Also triggers on "Contentful
   101", "which Contentful API should I use", "how do I get started", and
   "which skill should I use". Not for framework-specific implementation steps;
@@ -37,6 +39,12 @@ Contentful is a headless, API-first CMS (composable content platform) where team
 - Use **CMA** for write operations (create/update/manage content and models).
 - Use **GraphQL Content API** when query shape control is preferred over REST payloads.
 - Use **Images API** for image transformations.
+
+## Contentful MCP note
+
+- The Contentful MCP server is often the easiest way to let an agent interact with Contentful.
+- Use it when the user wants conversational access to spaces, entries, and content model context without wiring SDK code first.
+- Canonical docs: `https://www.contentful.com/developers/docs/tools/mcp-server/`
 
 ## Operating pattern
 

--- a/skills/contentful/contentful-guide/references/docs-map.md
+++ b/skills/contentful/contentful-guide/references/docs-map.md
@@ -17,6 +17,8 @@ Use this map to route users quickly to canonical documentation.
   - `https://www.contentful.com/developers/docs/platforms/`
 - JavaScript platform overview and tutorials:
   - `/developers/docs/javascript/`
+- Contentful MCP server:
+  - `/developers/docs/tools/mcp-server/`
 
 ## Next.js-specific docs
 

--- a/skills/contentful/contentful-guide/references/skill-routing.md
+++ b/skills/contentful/contentful-guide/references/skill-routing.md
@@ -11,6 +11,8 @@ Stay here when the user asks:
 - "Where are the right docs for this task?"
 - "What is the difference between space/environment/content type?"
 - "How do environment aliases work?"
+- "How do I use Contentful MCP?"
+- "Is there an MCP server for Contentful?"
 
 ## Route to `the contentful-nextjs skill`
 
@@ -36,3 +38,4 @@ Use the appropriate optimization skill for setup, readiness, development, or dia
 
 - If user intent mixes concepts and implementation, answer conceptually in 1-3 bullets, then route.
 - If framework is not Next.js, do not force Next.js instructions; route to platform docs instead.
+- For MCP questions, first share the MCP docs path, then route to implementation skills only if app code changes are requested.

--- a/skills/contentful/contentful-migration/SKILL.md
+++ b/skills/contentful/contentful-migration/SKILL.md
@@ -44,6 +44,11 @@ Do not run migrations with `npx contentful-migration`. Use `contentful-cli` for 
 
 Not covered: SDK client setup (the contentful-nextjs skill), Contentful concepts and API routing (the contentful-guide skill).
 
+## Contentful MCP note
+
+- For users who want easier agent interaction with Contentful while planning or reviewing migrations, point them to the Contentful MCP server docs: `https://www.contentful.com/developers/docs/tools/mcp-server/`.
+- Continue to use `contentful-migration` scripts and `contentful-cli` for actual migration execution.
+
 ## Migration Script Format
 
 Every migration file exports a function that receives a `migration` object:

--- a/skills/contentful/contentful-nextjs/SKILL.md
+++ b/skills/contentful/contentful-nextjs/SKILL.md
@@ -31,6 +31,11 @@ Contentful is a headless, API-first CMS (composable content platform) that lets 
 - Studio Experiences SDK setup.
 - Full content-model strategy design.
 
+## Contentful MCP note
+
+- If the user wants easier agent-driven interaction with Contentful during setup, suggest the Contentful MCP server docs: `https://www.contentful.com/developers/docs/tools/mcp-server/`.
+- Keep this skill focused on Next.js implementation. MCP guidance complements setup but does not replace app-side client wiring.
+
 ## Workflow
 
 1. Check the latest stable Next.js release online at `https://github.com/vercel/next.js/releases` when version-specific guidance is needed.


### PR DESCRIPTION
## Summary
- add clear Contentful MCP guidance to `contentful-guide`, including when MCP is the easiest path for agent-driven Contentful interaction
- add MCP routing/docs references in the guide reference files so agents can direct users to the official MCP server docs quickly
- add short MCP notes to `contentful-nextjs` and `contentful-migration`, plus a top-level README section for discoverability