### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: skills
+  description: Skills for teaching agents how to build on Contentful
+  annotations:
+    github.com/project-slug: contentful/skills
+    contentful.com/service-tier: "4"
+    contentful.com/ci-alert-slack: alerts-group-optimization
+  tags:
+    - sast-disabled
+    - tier-4
+spec:
+  type: library
+  lifecycle: production
+  owner: group:team-optimization


### PR DESCRIPTION
## Summary

- Adds `catalog-info.yaml` for Backstage service catalog registration
- Tier 4, team-optimization owner, CI alerts to `alerts-group-optimization`

## Test plan

- [ ] Verify the component appears in Backstage after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)