### PR TITLE
chore(deps): bump skill-kit to 0.4.3 and align workspace config []

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "update-licenses": "node ./scripts/update-licenses.mjs"
   },
   "devDependencies": {
-    "@contentful/skill-kit": "^0.4.0",
+    "@contentful/skill-kit": "^0.4.3",
     "@release-it/bumper": "^7.0.5",
     "@release-it/conventional-changelog": "^10.0.6",
     "@types/node": "^25.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@contentful/skill-kit':
-        specifier: ^0.4.0
-        version: 0.4.0
+        specifier: ^0.4.3
+        version: 0.4.3
       '@release-it/bumper':
         specifier: ^7.0.5
         version: 7.0.5(release-it@19.2.4(@types/node@25.6.0))
@@ -32,8 +32,8 @@ importers:
 
 packages:
 
-  '@contentful/skill-kit@0.4.0':
-    resolution: {integrity: sha512-iNlJIvcFuCXl5tf5Wnlc4+r54oaRDafNFmJ6hKhTcdTI9QOXcG2HO58dbqZQ7vqCChXAbLA1bLEcjGiYxxsPEQ==, tarball: https://npm.pkg.github.com/download/@contentful/skill-kit/0.4.0/086a149b9bec86e5a15e10343c12d5e379ca2b55}
+  '@contentful/skill-kit@0.4.3':
+    resolution: {integrity: sha512-L1ImLMbl/8j7LplHHL/myTwK4UimmSWo6eKzqmTkxJ2YBURiyeGSeoHz5KFQ5gzK/U+sivO6adnXGWcOTL4wmQ==, tarball: https://npm.pkg.github.com/download/@contentful/skill-kit/0.4.3/c0a81d5f32e11df64bba5b32e624f10a2a810754}
     engines: {node: '>=24'}
     hasBin: true
 
@@ -1505,7 +1505,7 @@ packages:
 
 snapshots:
 
-  '@contentful/skill-kit@0.4.0':
+  '@contentful/skill-kit@0.4.3':
     dependencies:
       esbuild: 0.28.0
       tsx: 4.21.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+  - esbuild

--- a/skills/contentful-personalization/SKILL.md
+++ b/skills/contentful-personalization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: contentful-personalization
-description: Unified Contentful personalization skill. Covers readiness assessment, guided setup, diagnostics and debugging, day-to-day development, and reference documentation for SDKs, APIs, and patterns. Trigger keywords: personalization, optimization, ninetailed, A/B test, set up personalization, personalization not working, personalize this component, am I ready for personalization, experience API
+description: "Unified Contentful personalization skill. Covers readiness assessment, guided setup, diagnostics and debugging, day-to-day development, and reference documentation for SDKs, APIs, and patterns. Trigger keywords: personalization, optimization, ninetailed, A/B test, set up personalization, personalization not working, personalize this component, am I ready for personalization, experience API"
 metadata:
   version: "1.0.0"
 ---


### PR DESCRIPTION
## Summary
- upgrade `@contentful/skill-kit` from `0.4.0` to `0.4.3` in the root `package.json` and refresh lockfile entries.
- add `pnpm-workspace.yaml` with `onlyBuiltDependencies` for `esbuild` to align pnpm workspace behavior.
- quote the long `description` string in `skills/contentful-personalization/SKILL.md` to keep YAML parsing explicit and stable.