### PR TITLE
feat: add Contentful MCP server and consolidate docs []

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "contentful-skills",
+  "name": "contentful",
   "owner": {
     "name": "Contentful",
     "email": "skills@contentful.com"
@@ -17,10 +17,7 @@
         "./skills/contentful-guide",
         "./skills/contentful-migration",
         "./skills/contentful-nextjs",
-        "./skills/contentful-personalization-dev",
-        "./skills/contentful-personalization-doctor",
-        "./skills/contentful-personalization-readiness",
-        "./skills/contentful-personalization-setup"
+        "./skills/contentful-personalization"
       ]
     }
   ]

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -12,6 +12,7 @@
   },
   "keywords": [
     "contentful",
+    "cms",
     "personalization",
     "analytics",
     "ninetailed"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,6 @@
+{
+  "contentful-mcp": {
+    "type": "http",
+    "url": "https://mcp.contentful.com/mcp"
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ skills/                    Distributed to customers via `npx skills add contentf
 
 `skills/` is the **distribution boundary**. Only its contents are installed to customer environments. Everything outside (`AGENTS.md`, `.agents/`, `.claude-plugin/`) stays in the repo.
 
-The `skills` CLI discovers skills recursively, so subdirectories work correctly. Skills are organized in a flat structure directly under `skills/` (e.g., `skills/contentful-personalization-readiness/`).
+The `skills` CLI discovers skills recursively, so subdirectories work correctly. Skills are organized in a flat structure directly under `skills/` (e.g., `skills/contentful-personalization/`).
 
 ## Skill Requirements
 
@@ -26,9 +26,9 @@ Even documentation-only skills require both files.
 
 ## Naming Conventions
 
-- **Directory names**: lowercase, hyphen-separated, prefixed with the domain (e.g., `contentful-personalization-readiness`, `contentful-personalization-setup`)
+- **Directory names**: lowercase, hyphen-separated, prefixed with the domain (e.g., `contentful-personalization`, `contentful-migration`)
 - **`name` field** in SKILL.md frontmatter: must exactly match the immediate parent directory name
-- **`package.json` name**: `@contentful/skill-<skill-name>` (e.g., `@contentful/skill-contentful-personalization-readiness`)
+- **`package.json` name**: `@contentful/skill-<skill-name>` (e.g., `@contentful/skill-contentful-personalization`)
 
 ### Name Rules (agentskills.io spec)
 
@@ -69,7 +69,7 @@ Use [conventional commits](https://www.conventionalcommits.org/) with a Jira tic
 **Examples**:
 ```
 feat(optimization): add readiness skill [NT-2950]
-fix(contentful-personalization-doctor): correct SDK version detection [NT-2955]
+fix(contentful-personalization): correct SDK version detection [NT-2955]
 docs: update README with new install commands [NT-2960]
 ```
 
@@ -84,7 +84,7 @@ Some skills are built with [`@contentful/skill-kit`](https://github.com/contentf
 
 Build maps source to distribution:
 ```
-skill-kit build src/skills/contentful-personalization-doctor/skill.ts -o skills/contentful-personalization-doctor --mode node
+skill-kit build src/skills/contentful-personalization/skill.ts -o skills/contentful-personalization --mode node
 ```
 
 The `--mode node` flag produces a single `.mjs` bundle that runs on the host's Node.js (≥24) instead of self-contained platform binaries. This keeps the repo lightweight.
@@ -103,7 +103,7 @@ Skills are installed by customers via the [skills CLI](https://github.com/vercel
 
 ```bash
 npx skills add contentful/skills                          # all skills
-npx skills add contentful/skills --skill contentful-personalization-readiness  # one skill
+npx skills add contentful/skills --skill contentful-personalization  # one skill
 ```
 
 The CLI copies skill directories in isolation. Each skill must be fully self-contained — no dependencies on files outside its own directory.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Contentful GmbH
+Copyright (c) 2026 Contentful
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ npx skills add contentful/skills
 # Claude Code
 claude /install-skill contentful/skills
 
+# Cursor (Plugin Marketplace)
+/plugin marketplace add contentful/skills
+
 # Cursor / Copilot / Codex
 # Auto-discovers from .agents/skills/ when added to project
 

--- a/README.md
+++ b/README.md
@@ -19,15 +19,7 @@ npx skills add contentful/skills
 | **contentful-guide** | "Contentful 101", "which Contentful API should I use", "which skill should I use" | Coming soon |
 | **contentful-nextjs** | "add Contentful to Next.js", "Next.js Contentful setup", "Draft Mode Contentful" | Coming soon |
 | **contentful-migration** | "write a migration", "create content type", "schema migration" | Coming soon |
-
-### Personalization
-
-| Skill | Triggers | Status |
-|-------|----------|--------|
-| **contentful-personalization-readiness** | "check optimization readiness", "audit personalization setup" | Coming soon |
-| **contentful-personalization-setup** | "set up optimization", "configure personalization" | Coming soon |
-| **contentful-personalization-dev** | "build personalization component", "add analytics hook" | Coming soon |
-| **contentful-personalization-doctor** | "diagnose optimization issues", "troubleshoot personalization" | Coming soon |
+| **contentful-personalization** | "set up personalization", "optimization readiness", "Ninetailed", "A/B test", "personalization not working", "experience API" | Coming soon |
 
 ## Platform Install Commands
 
@@ -48,7 +40,7 @@ gemini skills install contentful/skills
 ### Install a single skill
 
 ```bash
-npx skills add contentful/skills --skill contentful-personalization-readiness
+npx skills add contentful/skills --skill contentful-personalization
 ```
 
 ## Contentful MCP Server

--- a/local-skills/skills/skill-authoring/SKILL.md
+++ b/local-skills/skills/skill-authoring/SKILL.md
@@ -41,10 +41,12 @@ determines whether the skill activates. Keep the `SKILL.md` body concise (under
 
 ```
 skills/                         Distributed to customers (distribution boundary)
-  contentful-personalization-readiness/   A skill — name field is "contentful-personalization-readiness"
+  contentful-personalization/   A skill — name field is "contentful-personalization"
     SKILL.md
     package.json
     references/
+    scripts/
+    bin/
 .agents/skills/                 Internal contributor skills (never distributed)
   skill-authoring/
     SKILL.md
@@ -128,8 +130,9 @@ description: >-
   Validates configuration, SDK versions, API connectivity. Use when
   troubleshooting optimization problems, debugging personalization behavior,
   or checking why experiments aren't running. Also triggers on "why isn't
-  personalization working" or "check my config". Not for initial setup —
-  use the contentful-personalization-setup skill for that.
+  personalization working" or "check my config". Not for initial end-to-end
+  setup from scratch — that is covered by the onboard flow in the same
+  `contentful-personalization` skill.
 ```
 
 **Bad:**
@@ -142,7 +145,7 @@ Include:
 - Direct trigger keywords the user would naturally say
 - Indirect keywords (e.g., for a deploy skill, also mention "ship", "release")
 - Negative scope to prevent false activations
-- Cross-references to related skills with explicit phrasing (for example, `the contentful-personalization-setup skill`)
+- Cross-references to related skills with explicit phrasing (for example, `the contentful-guide skill` for general CMS help)
 
 ## Directory Structure
 
@@ -211,9 +214,9 @@ frontmatter should mirror `package.json` version.
 
 | Context | Pattern | Example |
 |---------|---------|---------|
-| Directory name | `<domain>-<subdomain>-<skill>`, lowercase-hyphen | `contentful-personalization-readiness` |
-| `name` field | must match directory | `contentful-personalization-readiness` |
-| npm package | `@contentful/skill-<skill-name>` | `@contentful/skill-contentful-personalization-readiness` |
+| Directory name | `<domain>-<product-or-topic>`, lowercase-hyphen | `contentful-personalization` |
+| `name` field | must match directory | `contentful-personalization` |
+| npm package | `@contentful/skill-<skill-name>` | `@contentful/skill-contentful-personalization` |
 
 Name validation rules: 1-64 chars, `[a-z0-9-]` only, no leading/trailing/consecutive
 hyphens, must match parent directory name exactly.
@@ -236,22 +239,21 @@ the design rules below.
 **Simple skills** — executables directly in `scripts/`:
 
 ```
-contentful-personalization-doctor/
+contentful-personalization/
   scripts/
-    check                 Bash script, Python script, etc. (chmod +x)
-    fix
+    run                 Entry script (chmod +x) or thin wrapper
 ```
 
 **Complex skills** — wrappers in `scripts/` delegate to an implementation
-directory (e.g., `src/`):
+directory (e.g., `src/`, `bin/`):
 
 ```
-contentful-personalization-doctor/
+my-code-skill/
   scripts/
-    check                 Thin wrapper → delegates to src/
-    fix                   Thin wrapper → delegates to src/
-  src/                    Implementation (any language/structure)
+    check                 Thin wrapper → delegates to src/ or bin/
+  src/                    Optional — TypeScript source for skill-kit builds
     ...
+  bin/                    Optional — compiled output
 ```
 
 The wrapper decouples the skill's contract from its implementation. You can
@@ -303,8 +305,9 @@ For output patterns, exit code conventions, and `--help` templates, see
 Use explicit phrasing in SKILL.md body to reference related skills:
 
 ```markdown
-Before running this, ensure the contentful-personalization-readiness skill checks pass.
-For initial SDK installation, use the contentful-personalization-setup skill instead.
+For personalization, use the contentful-personalization skill. Its onboard
+flow covers readiness and SDK install; the doctor flow covers troubleshooting.
+For "which API should I use", use the contentful-guide skill.
 ```
 
 This is a documentation convention for the agent — no runtime enforcement.
@@ -321,7 +324,7 @@ This is a documentation convention for the agent — no runtime enforcement.
 ### Checklist
 
 1. Choose the right location:
-   - Customer-facing skill → `skills/<domain>/<skill-name>/`
+   - Customer-facing skill → `skills/<skill-name>/` (flat, one directory per skill)
    - Internal contributor skill → `.agents/skills/<skill-name>/`
 
 2. Create the directory with the skill name as directory name

--- a/local-skills/skills/skill-authoring/references/conventions.md
+++ b/local-skills/skills/skill-authoring/references/conventions.md
@@ -54,8 +54,8 @@ Describe how to validate the result.
 
 ## Related Skills
 
-- the contentful-personalization-setup skill — for initial SDK installation
-- the contentful-personalization-doctor skill — for troubleshooting issues
+- the `contentful-personalization` skill — onboarding, development, and diagnostics in one package
+- the `contentful-guide` skill — which API to use and how to pick a skill
 ```
 
 ### Code skill with scripts
@@ -122,11 +122,11 @@ For API details, see [references/api.md](references/api.md).
 
 ```json
 {
-  "name": "@contentful/skill-contentful-personalization-readiness",
+  "name": "@contentful/skill-contentful-personalization",
   "version": "1.0.0",
-  "description": "Assess optimization and personalization readiness for a Contentful project",
+  "description": "Contentful optimization and personalization (onboard, develop, doctor flows)",
   "license": "MIT",
-  "files": ["SKILL.md", "references/**", "scripts/**", "assets/**"]
+  "files": ["SKILL.md", "references/**", "scripts/**", "assets/**", "bin/**"]
 }
 ```
 
@@ -173,7 +173,7 @@ description: >-
   SDK compatibility. Use when asked to check optimization readiness, audit
   personalization setup, or evaluate prerequisites. Also triggers on "am I
   ready for personalization" or "can my app support A/B testing". Not for
-  setting up SDKs — use the contentful-personalization-setup skill for that.
+  unrelated Contentful topics — use the `contentful-guide` skill for API basics.
 ```
 
 ```yaml
@@ -184,7 +184,8 @@ description: >-
   handling, and hydration. Use when asked to set up optimization, configure
   personalization, install Ninetailed SDK, or initialize A/B testing. Also
   triggers on "add personalization to my project", "configure edge rendering",
-  or "set up experiments". Not for diagnosing issues — use the contentful-personalization-doctor skill.
+  or "set up experiments". For broken installs or production debugging, use
+  the doctor flow in the same `contentful-personalization` skill.
 ```
 
 ### Bad Examples
@@ -321,7 +322,7 @@ Document exit codes in `--help` output.
 ### Minimum (documentation-only)
 
 ```
-contentful-personalization-readiness/
+contentful-migration/
   SKILL.md
   package.json
 ```
@@ -329,23 +330,23 @@ contentful-personalization-readiness/
 ### With references
 
 ```
-contentful-personalization-readiness/
+contentful-nextjs/
   SKILL.md
   package.json
   references/
-    checklist.md
-    component-patterns.md
+    draft-mode.md
+    app-router.md
 ```
 
 ### With scripts (simple)
 
 ```
-contentful-personalization-doctor/
+contentful-personalization/
   SKILL.md
   package.json
   scripts/
-    check               Executable (chmod +x)
-    fix                 Executable (chmod +x)
+    run                 Executable (chmod +x) — skill-kit CLI entry
+  bin/                  Optional — compiled bundle
 ```
 
 Use this when scripts are small and self-contained.
@@ -353,13 +354,12 @@ Use this when scripts are small and self-contained.
 ### With scripts (complex — with implementation dir)
 
 ```
-contentful-personalization-doctor/
+my-code-skill/
   SKILL.md
   package.json
   scripts/
-    check               Wrapper (chmod +x) → delegates to src/
-    fix                 Wrapper (chmod +x) → delegates to src/
-  src/                  Implementation (language of your choice)
+    check               Wrapper (chmod +x) → delegates to src/ or bin/
+  src/                  Implementation (e.g. skill-kit TypeScript source)
     ...
   references/
     api.md
@@ -371,22 +371,22 @@ a build step or unit tests.
 ### Full skill with everything
 
 ```
-contentful-personalization-setup/
+contentful-personalization/
   SKILL.md
   package.json
   scripts/
-    setup               Wrapper → delegates to src/
-    validate            Wrapper → delegates to src/
-  src/
-    ...
+    run                 Wrapper to compiled CLI
+  bin/
+    *.mjs
   references/
     edge-setup.md
     middleware-guide.md
-    cookie-handling.md
-  assets/
+  assets/               Optional
     middleware-template.ts
-    config-template.json
 ```
+
+Skill-kit sources live under `src/skills/<name>/` at the repo root (not inside the
+distributed `skills/<name>/` folder).
 
 ## Naming Rules
 
@@ -400,10 +400,9 @@ With additional constraint: no consecutive hyphens (`--`).
 
 ### Valid names
 
-- `contentful-personalization-readiness`
-- `contentful-personalization-setup`
-- `contentful-personalization-dev`
-- `contentful-personalization-doctor`
+- `contentful-personalization`
+- `contentful-guide`
+- `contentful-migration`
 - `content-audit`
 - `a`
 - `my-skill-2`
@@ -420,12 +419,12 @@ With additional constraint: no consecutive hyphens (`--`).
 ### How directory names map to identifiers
 
 ```
-skills/contentful-personalization-readiness/SKILL.md
-       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+skills/contentful-personalization/SKILL.md
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^
        skill directory = name field
 
-name: contentful-personalization-readiness                     (SKILL.md frontmatter)
-"name": "@contentful/skill-contentful-personalization-readiness"  (package.json)
+name: contentful-personalization                            (SKILL.md frontmatter)
+"name": "@contentful/skill-contentful-personalization"      (package.json)
 ```
 
 The skill's identity comes from its immediate parent directory. The agentskills.io
@@ -441,10 +440,7 @@ contentful/skills/
 │   ├── contentful-guide/
 │   ├── contentful-migration/
 │   ├── contentful-nextjs/
-│   ├── contentful-personalization-readiness/
-│   ├── contentful-personalization-setup/
-│   ├── contentful-personalization-dev/
-│   └── contentful-personalization-doctor/
+│   ├── contentful-personalization/
 ├── .agents/skills/            ← INTERNAL (never distributed)
 │   └── skill-authoring/
 ├── .claude/skills             ← Symlink to .agents/skills/

--- a/local-skills/skills/skill-authoring/references/typescript-scripts.md
+++ b/local-skills/skills/skill-authoring/references/typescript-scripts.md
@@ -5,7 +5,7 @@ How to set up a skill with TypeScript scripts running on Node.js.
 ## Directory layout
 
 ```
-contentful-personalization-doctor/
+my-code-skill/
   SKILL.md
   package.json
   package-lock.json         Committed — pins dependency versions
@@ -26,6 +26,10 @@ contentful-personalization-doctor/
   references/
     api.md
 ```
+
+The live `contentful-personalization` skill is built with skill-kit at the monorepo
+level (`src/skills/contentful-personalization/`); this layout is a generic TypeScript
+skill pattern.
 
 ## Shell wrappers
 
@@ -50,7 +54,7 @@ public interface) to `src/` (the implementation).
 
 ```json
 {
-  "name": "@contentful/skill-contentful-personalization-doctor",
+  "name": "@contentful/skill-contentful-personalization",
   "version": "1.0.0",
   "description": "Diagnose and fix Contentful optimization issues",
   "license": "MIT",

--- a/skills/contentful-guide/SKILL.md
+++ b/skills/contentful-guide/SKILL.md
@@ -28,7 +28,7 @@ Contentful is a headless, API-first CMS (composable content platform) where team
 ## Routing rules
 
 - If the user asks to add Contentful to a Next.js project, use the contentful-nextjs skill.
-- If the user asks about optimization/personalization/analytics setup or debugging, route to contentful-personalization skills.
+- If the user asks about optimization/personalization/analytics setup or debugging, route to the `contentful-personalization` skill.
 - If the user asks for conceptual guidance, architecture tradeoffs, or where to read docs, stay in this skill.
 - If the user asks about environment aliases and deployment workflows, stay in this skill unless they also ask for framework implementation.
 

--- a/skills/contentful-guide/references/skill-routing.md
+++ b/skills/contentful-guide/references/skill-routing.md
@@ -24,7 +24,7 @@ Route when the user asks to:
 - configure Next.js env vars and Contentful client setup.
 - implement alias-aware environment configuration in Next.js.
 
-## Route to personalization skills
+## Route to the `contentful-personalization` skill
 
 Route when the user asks about:
 
@@ -32,7 +32,7 @@ Route when the user asks about:
 - Ninetailed/optimization SDK workflows,
 - troubleshooting optimization behavior.
 
-Use the appropriate contentful-personalization skill for setup, readiness, development, or diagnostics.
+That skill is unified: it covers onboarding (readiness and setup), day-to-day development, and diagnostics (`doctor` flow) in one install.
 
 ## Notes
 

--- a/skills/contentful-personalization/references/readiness-criteria.md
+++ b/skills/contentful-personalization/references/readiness-criteria.md
@@ -103,7 +103,7 @@ Report any gaps:
 
 ## Environment Variables Checklist
 
-### Required for Ninetailed (will be needed by the contentful-personalization-setup skill)
+### Required for Ninetailed (needed when you run the **onboard** flow in `contentful-personalization`)
 
 ```
 NEXT_PUBLIC_NINETAILED_CLIENT_ID    # Ninetailed API key
@@ -134,7 +134,7 @@ The overall verdict is the **worst** individual assessment, with one exception:
 
 - If the only issue is "no Ninetailed packages installed" (check C) but all
   other checks pass, the overall is still **READY** — installing packages is
-  what the contentful-personalization-setup skill handles.
+  what the **onboard** flow in the `contentful-personalization` skill handles.
 
 Hard gate:
 

--- a/src/skills/contentful-personalization/references/readiness-criteria.md
+++ b/src/skills/contentful-personalization/references/readiness-criteria.md
@@ -103,7 +103,7 @@ Report any gaps:
 
 ## Environment Variables Checklist
 
-### Required for Ninetailed (will be needed by the contentful-personalization-setup skill)
+### Required for Ninetailed (needed when you run the **onboard** flow in `contentful-personalization`)
 
 ```
 NEXT_PUBLIC_NINETAILED_CLIENT_ID    # Ninetailed API key
@@ -134,7 +134,7 @@ The overall verdict is the **worst** individual assessment, with one exception:
 
 - If the only issue is "no Ninetailed packages installed" (check C) but all
   other checks pass, the overall is still **READY** — installing packages is
-  what the contentful-personalization-setup skill handles.
+  what the **onboard** flow in the `contentful-personalization` skill handles.
 
 Hard gate:
 


### PR DESCRIPTION
## Summary

- **Add `.mcp.json`** — registers `@contentful/mcp-server` as a remote HTTP endpoint (`https://mcp.contentful.com/mcp`) so plugin users authenticate via OAuth instead of hardcoding API tokens
- **Rename plugin** from `contentful-skills` to `contentful` in `marketplace.json` and consolidate the four separate personalization skill entries into one `contentful-personalization`
- **Update docs** across AGENTS.md, README, skill-authoring guides, routing references, and readiness criteria to reflect the unified personalization skill
- **Minor housekeeping**: add `cms` keyword to Cursor plugin metadata, update LICENSE copyright holder

## Commits

| Commit | Description |
|--------|-------------|
| `feat(plugin): add Contentful MCP server via remote OAuth endpoint` | New `.mcp.json` with remote MCP config |
| `fix(plugin): rename plugin to "contentful" and consolidate personalization skills` | `marketplace.json` cleanup |
| `chore(plugin): add "cms" keyword to Cursor plugin metadata` | `.cursor-plugin/plugin.json` |
| `chore: update LICENSE copyright holder to "Contentful"` | Remove "GmbH" |
| `docs: update all references to unified contentful-personalization skill` | 9 files updated |

## Test plan

- [ ] Install plugin via `npx skills add contentful/skills` and verify MCP server connects with OAuth
- [ ] Verify `contentful-personalization` skill loads correctly as a single unified skill
- [ ] Confirm no broken references to old skill names (readiness, setup, dev, doctor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)