### PR TITLE
fix(personalization): prevent test side effect that breaks release-it

### DIFF
--- a/src/skills/contentful-personalization/skill.test.ts
+++ b/src/skills/contentful-personalization/skill.test.ts
@@ -13,19 +13,11 @@ test('classify routes to onboard for setup requests', async () => {
       classify: { intent: 'onboard', confidence: 0.95, reasoning: 'User wants to set up personalization' },
       'onboard/explore': {
         framework: 'nextjs-app', routerType: 'app', projectPath: '.', frameworkVersion: '14.0.0',
-        explorationSummary: 'Next.js project', personalizableCandidates: [], existingSetup: 'none', readinessOnly: false,
+        explorationSummary: 'Next.js project', personalizableCandidates: [], existingSetup: 'none',
+        readinessOnly: true,
       },
-      'onboard/assess': { readinessStatus: 'ready', report: 'All good', prerequisites: [], readinessOnly: false },
-      'onboard/recommend': { sdkChoice: 'ninetailed', architecture: 'client-only', reasoning: 'Simple setup' },
-      'onboard/confirm-choice': { approved: true },
-      'onboard/cms-setup': { choice: 'done' },
-      'onboard/plan': { approved: true, packagesToInstall: ['@ninetailed/experience.js'], envVars: {}, plan: 'Install SDK' },
-      'onboard/install': { projectPath: '.', packages: ['@ninetailed/experience.js'], packageManager: 'npm' },
-      'onboard/write-env': { projectPath: '.', variables: {}, fileName: '.env.local' },
-      'onboard/implement': { filesModified: [], summary: 'Done' },
-      'onboard/verify': { projectPath: '.' },
-      'onboard/fix': { fixesMade: ['fixed issue'] },
-      'onboard/report': { summary: 'Setup complete' },
+      'onboard/assess': { readinessStatus: 'ready', report: 'All good', prerequisites: [], readinessOnly: true },
+      'onboard/gate': { message: 'Readiness check complete' },
     }),
   });
 


### PR DESCRIPTION
## Summary

- The onboard routing test ran the full subskill lifecycle, which physically executed `npm install @ninetailed/experience.js` against the repo root via `installPackages` action
- This dirtied `package.json` and `pnpm-lock.yaml`, causing `release-it --ci` to fail with "Working dir must be clean" after the `before:init` test hook
- Short-circuits the onboard subskill via `readinessOnly: true` so it exits at the `gate` step before reaching `install` — the test only asserts dispatcher routing

## Test plan

- [x] `pnpm run test` — all 8 tests pass
- [x] `pnpm run typecheck && pnpm run test && git status` — working dir stays clean after hooks
- [ ] CI release workflow passes on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)