### PR TITLE
fix: remove hallucinated claude command []

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@ npx skills add contentful/skills
 # All platforms (auto-detects)
 npx skills add contentful/skills
 
-# Claude Code
-claude /install-skill contentful/skills
-
 # Cursor (Plugin Marketplace)
 /plugin marketplace add contentful/skills
 


### PR DESCRIPTION
This command doesn't exist in claude code 🙃. Using `npx ...` to install works well though with claude.