### PR TITLE
chore: [NT-3168] Update NOTICE file with missing dev dependencies

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -10,9 +10,24 @@ Development Dependencies
 @contentful/skill-kit
     License: MIT
     https://www.npmjs.com/package/@contentful/skill-kit [npmjs.com]
+@release-it/bumper
+    License: MIT
+    https://github.com/release-it/bumper [github.com]
+@release-it/conventional-changelog
+    License: MIT
+    https://github.com/release-it/conventional-changelog [github.com]
 @types/node
     License: MIT
     https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node [npmjs.com]
+oxlint
+    License: MIT
+    https://oxc.rs/docs/guide/usage/linter [oxc.rs]
+prettier
+    License: MIT
+    https://prettier.io [npmjs.com]
+release-it
+    License: MIT
+    https://github.com/release-it/release-it [github.com]
 tsx
     License: MIT
     https://tsx.is [npmjs.com]


### PR DESCRIPTION
## Summary

- Add 5 missing dev dependencies to NOTICE file: `@release-it/bumper`, `@release-it/conventional-changelog`, `oxlint`, `prettier`, `release-it`
- All are MIT-licensed, already covered by existing `licenses/MIT.txt`

## Test plan

- [x] Verify all listed packages match `package.json` devDependencies
- [x] Verify license info is correct for each package

🤖 Generated with [Claude Code](https://claude.com/claude-code)