### PR TITLE
docs: add contribution license section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,10 @@ pnpm run update-licenses
 - Update docs when behavior or usage changes.
 - Do not include secrets or credentials.
 
+## Contribution license
+
+By submitting a contribution to this project, you agree that your contribution is licensed under the MIT License that applies to this repository.
+
 ## Code of conduct
 
 By participating in this project, you agree to follow the Contentful Developer Code of Conduct:


### PR DESCRIPTION
## Summary

- Adds a "Contribution license" section to CONTRIBUTING.md clarifying that contributions are licensed under MIT

🤖 Generated with [Claude Code](https://claude.com/claude-code)