### PR TITLE
docs(licenses): specify Contentful Inc. in MIT license headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Contentful
+Copyright (c) 2026 Contentful Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/licenses/MIT.txt
+++ b/licenses/MIT.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) YEAR COPYRIGHT HOLDER
+Copyright (c) 2026 Contentful Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Update the root MIT license copyright holder to `Contentful Inc.`.
- Update the MIT template in `licenses/MIT.txt` to use `Contentful Inc.` for consistency.
- Align license ownership wording across repository-maintained MIT license files.