### PR TITLE
docs: add Claude plugin-dir local testing instructions [NT-0000]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,14 @@ mkdir -p .agents
 ln -sn "$(pwd)/local-skills/skills" .agents/skills
 ```
 
+To test the Claude plugin locally from this repository root:
+
+```sh
+claude --plugin-dir /path/to/contentful/skills
+```
+
+This loads the local plugin directly without installing it from a marketplace.
+
 ## Validate your changes
 
 Run the checks before opening a PR:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ ln -sn "$(pwd)/local-skills/skills" .agents/skills
 To test the Claude plugin locally from this repository root:
 
 ```sh
-claude --plugin-dir /path/to/contentful/skills
+claude --plugin-dir "$PWD"
 ```
 
 This loads the local plugin directly without installing it from a marketplace.


### PR DESCRIPTION
## Summary
- add a local Claude Code plugin testing command to `CONTRIBUTING.md`
- clarify that `claude --plugin-dir /path/to/contentful/skills` loads the repo plugin directly without marketplace installation

## Testing
- not run (docs-only)