### PR TITLE
docs(readme): fix plugin install marketplace name

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Two commands. You get four skills plus live MCP connections to your Contentful s
 
 ```
 /plugin marketplace add contentful/skills
-/plugin install contentful-skills@contentful-skills
+/plugin install contentful-skills@contentful
 ```
 
 Run `/reload-plugins` to activate. This registers two MCP servers:


### PR DESCRIPTION
## Summary
- Quickstart `/plugin install` command in `README.md` referenced marketplace `contentful-skills`, but the marketplace name registered in `.claude-plugin/marketplace.json` is `contentful` — running the command as written fails.
- Updated `README.md:31` from `contentful-skills@contentful-skills` to `contentful-skills@contentful` so the syntax matches `<plugin-name>@<marketplace-name>`.

## Test plan
- [x] `/plugin marketplace add contentful/skills` followed by `/plugin install contentful-skills@contentful` resolves the plugin in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)