### PR TITLE
docs: fix Claude Code plugin install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Two commands. You get seven skills plus live MCP connections to your Contentful 
 
 ```
 /plugin marketplace add contentful/skills
-/plugin install contentful@contentful
+/plugin install contentful-skills@contentful
 ```
 
 Run `/reload-plugins` to activate. This registers two MCP servers:


### PR DESCRIPTION
## Summary
Fix the Claude Code plugin install command in the README quickstart.

## Why this change
The README says:

    /plugin install contentful@contentful

This fails with: `Plugin "contentful" not found in marketplace "contentful"`

The plugin is named `contentful-skills`, so the correct command is:

    /plugin install contentful-skills@contentful

Verified today on Claude Code (latest), install succeeds, and the plugin loads with the MCP server.

## Validation
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm validate`
- [ ] `pnpm run update-licenses` (if dependencies changed)

*Docs-only change — no code affected.*

## Checklist
- [x] I have read `CONTRIBUTING.md`
- [x] Documentation is updated where needed
- [x] No secrets or credentials are included
- [x] No breaking changes, or they are clearly documented