### PR TITLE
docs: mention Cursor plugin [NT-3122]

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Skills also work without the plugin on any platform that supports the [agentskil
 
 ### Cursor
 
+Install the [Contentful Cursor plugin](https://cursor.directory/plugins/contentful-1) from Cursor Directory.
+
+Alternatively, add the skills manually:
+
 1. Open **Settings** → **Rules**
 2. Click **Add Rule** → **Remote Rule (GitHub)**
 3. Enter `contentful/skills`


### PR DESCRIPTION
## Summary
- Add the Contentful Cursor plugin link to the README Cursor setup section
- Keep the manual Remote Rule setup as an alternative