### PR TITLE
ci: add traffic stats export

### DIFF
--- a/.github/workflows/traffic-stats.yml
+++ b/.github/workflows/traffic-stats.yml
@@ -1,0 +1,77 @@
+name: Traffic stats
+
+# Daily snapshot of GitHub Traffic API stats (clones, views, top referrers)
+# uploaded to s3://mcp-usage-playground/skills/. Feeds the PRDA-976
+# dashboard for FY27 SP4 metrics. The Traffic API only retains 14 days of
+# history, so this must run at least once a fortnight to avoid permanent data
+# loss.
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: traffic-stats
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Retrieve Secrets from Vault
+        id: vault
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_URL }}
+          role: ${{ github.event.repository.name }}-github-action
+          method: jwt
+          path: github-actions
+          exportEnv: false
+          secrets: |
+            github/token/${{ github.event.repository.name }}-semantic-release token | GITHUB_TOKEN ;
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
+        with:
+          aws-access-key-id: ${{ secrets.USAGE_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.USAGE_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Fetch Traffic API and upload to S3
+        env:
+          GH_TOKEN: ${{ steps.vault.outputs.GITHUB_TOKEN }}
+          BUCKET: mcp-usage-playground
+          PREFIX: skills
+        run: |
+          set -euo pipefail
+          DT=$(date -u +%F)
+          REPO=${{ github.repository }}
+
+          declare -A endpoints=(
+            [clones]="traffic/clones"
+            [views]="traffic/views"
+            [referrers]="traffic/popular/referrers"
+          )
+
+          for kind in "${!endpoints[@]}"; do
+            path="${endpoints[$kind]}"
+            file="${kind}.json"
+            echo "Fetching /repos/${REPO}/${path}"
+            gh api "/repos/${REPO}/${path}" > "${file}"
+            aws s3 cp "${file}" \
+              "s3://${BUCKET}/${PREFIX}/${kind}/dt=${DT}/data.json" \
+              --content-type application/json
+          done
+
+          echo "## Traffic stats uploaded for ${DT}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          for kind in "${!endpoints[@]}"; do
+            echo "- s3://${BUCKET}/${PREFIX}/${kind}/dt=${DT}/data.json" >> "$GITHUB_STEP_SUMMARY"
+          done

--- a/package.json
+++ b/package.json
@@ -24,14 +24,6 @@
     "validate": "python3 local-skills/skills/skill-authoring/scripts/quick_validate.py skills --all",
     "update-licenses": "node ./scripts/update-licenses.mjs"
   },
-  "pnpm": {
-    "overrides": {
-      "basic-ftp": "5.3.1",
-      "express-rate-limit": "8.5.1",
-      "hono": "4.12.18",
-      "ip-address": "10.2.0"
-    }
-  },
   "devDependencies": {
     "@contentful/skill-kit": "^1.6.6",
     "@release-it/bumper": "^7.0.5",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,8 @@
+overrides:
+  basic-ftp: 5.3.1
+  express-rate-limit: 8.5.1
+  hono: 4.12.18
+  ip-address: 10.2.0
+
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
## Summary
Adds a scheduled GitHub Action that captures daily Traffic API stats for this repo and uploads them to `s3://mcp-usage-playground/skills/` partitioned by date.

Also moves pnpm overrides from `package.json` to `pnpm-workspace.yaml`, which is the local pnpm config location expected by pnpm 10+.

## Context
Copied and adapted from contentful/contentful-mcp-server#395. This feeds the PRDA-976 dashboard tracking external developer traction on public AI agent tooling. GitHub Traffic API data only retains 14 days of history, so daily collection prevents permanent data loss.

## How it works
- Schedule: daily at 03:00 UTC plus manual `workflow_dispatch`.
- GitHub auth: Vault-minted token from `github/token/${{ github.event.repository.name }}-semantic-release`.
- AWS auth: repo Actions secrets `USAGE_AWS_ACCESS_KEY_ID` and `USAGE_AWS_SECRET_ACCESS_KEY`.
- Output layout: `s3://mcp-usage-playground/skills/{clones,views,referrers}/dt=YYYY-MM-DD/data.json`.
- Data format: raw JSON from the GitHub Traffic API, uploaded with `application/json` content type.

## Required configuration
- `VAULT_URL` repo secret.
- Vault role `skills-github-action`.
- Vault token path `github/token/skills-semantic-release` with access to traffic endpoints.
- `USAGE_AWS_ACCESS_KEY_ID` repo secret.
- `USAGE_AWS_SECRET_ACCESS_KEY` repo secret.
- IAM permission for the AWS key: `s3:PutObject` on `s3://mcp-usage-playground/skills/*`.

## Test plan
- `pnpm install --frozen-lockfile`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run validate`
- `pnpm exec prettier --check package.json pnpm-workspace.yaml .github/workflows/traffic-stats.yml`

Post-merge: manually dispatch the workflow once, verify the three objects appear under today’s `dt=` prefix, then confirm the next 03:00 UTC scheduled run lands.