### PR TITLE
fix(ci): update traffic stats S3 prefix

### DIFF
--- a/.github/workflows/traffic-stats.yml
+++ b/.github/workflows/traffic-stats.yml
@@ -1,7 +1,7 @@
 name: Traffic stats
 
 # Daily snapshot of GitHub Traffic API stats (clones, views, top referrers)
-# uploaded to s3://mcp-usage-playground/skills/. Feeds the PRDA-976
+# uploaded to s3://mcp-usage-playground/mcp-skills/. Feeds the PRDA-976
 # dashboard for FY27 SP4 metrics. The Traffic API only retains 14 days of
 # history, so this must run at least once a fortnight to avoid permanent data
 # loss.
@@ -48,7 +48,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.vault.outputs.GITHUB_TOKEN }}
           BUCKET: mcp-usage-playground
-          PREFIX: skills
+          PREFIX: mcp-skills
         run: |
           set -euo pipefail
           DT=$(date -u +%F)

--- a/.github/workflows/traffic-stats.yml
+++ b/.github/workflows/traffic-stats.yml
@@ -1,7 +1,8 @@
 name: Traffic stats
 
 # Daily snapshot of GitHub Traffic API stats (clones, views, top referrers)
-# uploaded to s3://mcp-usage-playground/contentful-mcp-server/. Feeds the PRDA-976
+# uploaded to s3://s3-github-mcp-skills-usage-stats-043206427008-eu-central-1-an/skills/.
+# Feeds the PRDA-976
 # dashboard for FY27 SP4 metrics. The Traffic API only retains 14 days of
 # history, so this must run at least once a fortnight to avoid permanent data
 # loss.
@@ -42,13 +43,13 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.USAGE_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.USAGE_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+          aws-region: eu-central-1
 
       - name: Fetch Traffic API and upload to S3
         env:
           GH_TOKEN: ${{ steps.vault.outputs.GITHUB_TOKEN }}
-          BUCKET: mcp-usage-playground
-          PREFIX: contentful-mcp-server
+          BUCKET: s3-github-mcp-skills-usage-stats-043206427008-eu-central-1-an
+          PREFIX: skills
         run: |
           set -euo pipefail
           DT=$(date -u +%F)

--- a/.github/workflows/traffic-stats.yml
+++ b/.github/workflows/traffic-stats.yml
@@ -1,7 +1,7 @@
 name: Traffic stats
 
 # Daily snapshot of GitHub Traffic API stats (clones, views, top referrers)
-# uploaded to s3://mcp-usage-playground/mcp-skills/. Feeds the PRDA-976
+# uploaded to s3://mcp-usage-playground/contentful-mcp-server/. Feeds the PRDA-976
 # dashboard for FY27 SP4 metrics. The Traffic API only retains 14 days of
 # history, so this must run at least once a fortnight to avoid permanent data
 # loss.
@@ -48,7 +48,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.vault.outputs.GITHUB_TOKEN }}
           BUCKET: mcp-usage-playground
-          PREFIX: mcp-skills
+          PREFIX: contentful-mcp-server
         run: |
           set -euo pipefail
           DT=$(date -u +%F)


### PR DESCRIPTION
## Summary
Updates the traffic stats export prefix from `skills` to `mcp-skills` so uploads target the expected S3 namespace for the MCP skills usage stats AWS user.

## Context
The workflow successfully fetches GitHub Traffic API data, but S3 upload fails with `AccessDenied` on `s3://mcp-usage-playground/skills/...`. This changes the generated object keys to `s3://mcp-usage-playground/mcp-skills/{clones,views,referrers}/dt=YYYY-MM-DD/data.json`.

## Test plan
- Not run; workflow-only prefix change.

Post-merge: manually dispatch the Traffic stats workflow and verify the three objects land under today's `mcp-skills` `dt=` partition.