### PR TITLE
fix(contentful-nextjs): draftMode() and page params are async since Next.js 15

### DIFF
--- a/skills/contentful-nextjs/references/preview-and-draft-mode.md
+++ b/skills/contentful-nextjs/references/preview-and-draft-mode.md
@@ -22,12 +22,19 @@ Use this pattern when editors need to preview unpublished content in Next.js.
 import { draftMode } from "next/headers";
 import { getEntryById } from "@/lib/contentful/queries";
 
-export default async function Page({ params }: { params: { slug: string } }) {
-  const { isEnabled } = draftMode();
-  const entry = await getEntryById(params.slug, isEnabled);
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const { isEnabled } = await draftMode();
+  const entry = await getEntryById(slug, isEnabled);
   return <main>{entry?.fields?.title as string}</main>;
 }
 ```
+
+`params` and `draftMode()` are both async as of Next.js 15 — await them rather than reading the values synchronously.
 
 ## Preview-aware GraphQL guidance
 


### PR DESCRIPTION
## Summary

The Draft Mode reference example (`skills/contentful-nextjs/references/preview-and-draft-mode.md`) still showed the pre-Next.js-15 synchronous form:

```ts
export default async function Page({ params }: { params: { slug: string } }) {
  const { isEnabled } = draftMode();
  const entry = await getEntryById(params.slug, isEnabled);
```

`draftMode()` has been async since [v15.0.0-RC](https://nextjs.org/docs/app/api-reference/functions/draft-mode#version-history), and page `params` became a `Promise` in the same release. Copying this example as-is on a current Next.js project produces a type error (or triggers the deprecated synchronous-access warning, which Next.js says will stop working in a future version).

Fixed to await both, matching the current official docs example.

## Test plan

- [x] Confirmed the fix against the live Next.js docs (`draftMode` API reference, version 16.2.12, "Good to know" section: *"`draftMode` is an asynchronous function that returns a promise... In version 14 and earlier, `draftMode` was a synchronous function... this behavior will be deprecated in the future"*).
- [x] `python3 local-skills/skills/skill-authoring/scripts/quick_validate.py skills --all` — 7/7 skills pass, including `contentful-nextjs`.
- [x] Scoped to this one file — no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)