### PR TITLE
fix(ci): prevent concurrent release workflow races []

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: release-${{ github.repository }}
+  cancel-in-progress: true
+
 permissions:
   id-token: write
 
@@ -65,6 +69,9 @@ jobs:
         run: pnpm install --frozen-lockfile
         env:
           NODE_AUTH_TOKEN: ${{ steps.vault.outputs.GITHUB_PACKAGES_WRITE_TOKEN }}
+
+      - name: Sync with main
+        run: git pull --rebase origin main
 
       - name: Release
         run: pnpm exec release-it --ci


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add a `concurrency` group to the Release workflow so only one release job runs at a time when multiple commits land on `main` in quick succession
- Cancel in-progress release runs when a newer one starts, so burst merges produce a single release instead of racing version bumps
- Rebase onto latest `main` before `release-it` runs to avoid non-fast-forward push failures

## Why this change

The Release workflow failed on 2026-09-01 for `chore(deps): update dependency express-rate-limit to v8.7.0 (#129)` because three Renovate PRs merged within ~2 minutes. Parallel release jobs each tried to bump, tag, and push `v2.4.33`, and the slower run was rejected with:

```
! [rejected] main -> main (non-fast-forward)
```

Later merges recovered (releases `v2.4.33` and `v2.4.34` succeeded), but the failed run still triggered the `#alerts-group-optimization` alert.

## Validation

- [x] Workflow change only — no application code affected
- [ ] CI on this PR

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] Documentation is updated where needed
- [x] No secrets or credentials are included
- [x] No breaking changes, or they are clearly documented
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://contentful.slack.com/archives/C09PE66UUN9/p1788251105125329?thread_ts=1788251105.125329&cid=C09PE66UUN9)

<div><a href="https://cursor.com/agents/bc-63029c69-bd61-51a3-9eff-7e45efdfe044?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63029c69-bd61-51a3-9eff-7e45efdfe044&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

